### PR TITLE
docs: add license, CLA, contributing guide, AI policy, and PR workflows

### DIFF
--- a/.github/workflows/CLA.yml
+++ b/.github/workflows/CLA.yml
@@ -1,0 +1,49 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I agree to the Zangetsu CLA v1') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://github.com/Spyou/Zangetsu/blob/main/CLA.md"
+
+          branch: "cla-signatures"
+
+          allowlist: Spyou,Ombryal,weblate,dependabot[bot],dependabot-preview[bot],github-actions[bot]
+
+          remote-organization-name: ""
+          remote-repository-name: ""
+
+          custom-pr-sign-comment: "I agree to the Zangetsu CLA v1"
+
+          custom-notsigned-prcomment: |
+            Thank you for your contribution to Zangetsu! 🎉
+
+            Before we can merge this, please read our [Contributor License Agreement](https://github.com/Spyou/Zangetsu/blob/main/CLA.md) and confirm you agree by replying to this PR with the following exact comment:
+
+            > I agree to the Zangetsu CLA v1
+
+          custom-pr-sign-comment-hint: "Copy and paste the sentence above exactly as shown to sign."
+
+          custom-allsigned-prcomment: "All contributors have signed the CLA. ✅ Thanks for contributing to Zangetsu!"
+
+          lock-pullrequest-aftermerge: false

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,109 @@
+# AI Usage Policy for Zangetsu
+
+**Last Updated: August 3, 2026**
+
+AI tools (Copilot, ChatGPT, Claude, Cursor, etc.) are welcome for contributing to Zangetsu — used well, they're a normal part of how software gets written in 2026. This policy exists to make sure AI-assisted contributions meet the same bar as any other contribution: correct, legally clean, and something a human actually understands and stands behind.
+
+---
+
+## TL;DR
+
+- AI-assisted contributions are **allowed**.
+- You must **disclose** that AI was used, and to what extent.
+- You are **fully responsible** for AI-generated code you submit — "the AI wrote it" is not a defense against bugs, license violations, or security issues.
+- You must **understand and have tested** anything you submit, AI-written or not.
+- Extra care applies to **providers/extractors** — see Section 5.
+- The CLA still applies in full; AI assistance doesn't change your obligations under it. In fact, the CLA's Section 5 promises now explicitly include "if AI tools were used to help create the Contribution, its use complies with this policy" — so signing the CLA means agreeing to this document too.
+
+---
+
+## 1. Disclosure Requirement
+
+If a Contribution was substantially written, generated, or refactored with AI assistance, say so in the pull request description. A short note is enough:
+
+```
+AI assistance: used Claude to draft the initial extractor logic, reviewed
+and tested manually.
+```
+
+You don't need to disclose minor, ordinary uses (autocomplete-style suggestions, AI-assisted debugging of your own code, spell-checking a comment). The bar is: **if a reviewer would reasonably want to know AI was involved in producing the logic, disclose it.**
+
+Non-disclosure of substantial AI-generated content, discovered later, will be treated as a good-faith violation of this policy and may result in the PR being closed and future Contributions receiving closer scrutiny.
+
+---
+
+## 2. You Own What You Submit
+
+Submitting an AI-assisted Contribution means you are certifying, same as with any other Contribution under the [CLA](CLA.md):
+
+- You've **read and understood** the code, not just pasted it in.
+- You've **tested it** — AI-generated code frequently looks plausible while being subtly wrong, especially around edge cases, async logic, and platform-specific behavior.
+- You take responsibility for bugs, security issues, or license problems it introduces, exactly as if you'd written it by hand.
+
+"An AI wrote this" is never an acceptable answer to "why does this code do X" during review.
+
+---
+
+## 3. License and Copyright Cleanliness
+
+AI models can reproduce memorized snippets from their training data, sometimes verbatim, without flagging that it's someone else's copyrighted or differently-licensed code. Before submitting AI-assisted code:
+
+- Check for anything that looks like it was lifted from a specific existing project (unusual comments, distinctive variable names matching a known library, license headers, etc.).
+- If AI output includes or closely resembles code from a project under a license incompatible with GPLv3 (or requiring attribution you haven't given), **do not submit it** — rewrite the logic yourself or find a compatible reference implementation.
+- This is the same disclosure obligation already in **Section 5 of the CLA** ("if the Contribution includes third-party code, assets, data, or references, you have clearly identified them...") — AI-generated code is not exempt just because a model produced it instead of a human copy-pasting.
+- If your Contribution is derived from, or closely modeled on, a specific third-party project (the way Zangetsu's existing CloudStream and Aniyomi/Tachiyomi integrations are), that needs its own entry in [`NOTICE.md`](NOTICE.md), same as any other third-party-derived code — regardless of whether a human or an AI wrote the derivation.
+
+---
+
+## 4. Security
+
+AI-generated code has a track record of introducing subtle security issues — unsanitized inputs, weak crypto usage, unsafe deserialization, secrets accidentally hardcoded, overly permissive exported components, etc. If your Contribution touches:
+
+- Authentication or token handling
+- Anything parsing untrusted input (subtitles, remote JSON/config, `.cs3`-style extension payloads)
+- Network requests to third-party sources
+
+review AI-generated code in those paths especially carefully, and call it out in your PR so reviewers know to look closely.
+
+---
+
+## 5. Providers, Extractors, and Scraping Logic
+
+This is the area where AI-assisted contributions need the most caution, because the legal risk isn't just about Zangetsu's own code:
+
+- **Don't let AI invent plausible-looking scraping logic for a source you haven't personally verified.** AI models will confidently generate code that *looks* like it scrapes a real site correctly while being outdated, wrong, or targeting something that never worked to begin with.
+- **Don't use AI to help bypass anti-scraping protections, rate limits, DRM, or authentication on a third-party source** you don't have the right to access that way. This applies regardless of whether a human or an AI wrote the bypass.
+- If an AI-assisted provider/extractor PR is later found to violate a source's terms of service in a way you didn't personally verify, responsibility for that still falls on you as the Contributor, per the CLA's indemnification terms (Section 8).
+
+---
+
+## 6. What AI Assistance Is Good For Here
+
+To be clear this isn't a discouragement policy — AI tools are genuinely useful for:
+
+- Drafting documentation, README updates, and code comments
+- Writing and expanding test coverage
+- Boilerplate (DTOs, serialization models, repetitive UI scaffolding)
+- Debugging assistance and explaining unfamiliar code
+- Translation drafts (still needs a fluent human to check accuracy — see `CONTRIBUTING.md`)
+- Refactoring suggestions you then review and apply deliberately
+
+Use it for these freely, disclosure requirements in Section 1 still apply where relevant.
+
+---
+
+## 7. Maintainer Review Rights
+
+Maintainers may ask you directly whether/how AI was used on any PR, and may request additional explanation or testing evidence for AI-assisted Contributions before merging. This isn't an accusation — it's a normal part of review, the same way a maintainer might ask about a Contribution's origin for any other reason.
+
+Maintainers reserve the right to decline AI-assisted Contributions that don't meet the bar in Sections 2–5, same as any other Contribution that isn't ready to merge.
+
+---
+
+## 8. Relationship to the CLA and LICENSE
+
+This policy doesn't modify the [CLA](CLA.md) or [LICENSE](LICENSE) — it clarifies how existing obligations (originality, no undisclosed third-party code, indemnification, no warranty) apply specifically to AI-assisted work. Where anything here seems to conflict with the CLA or LICENSE, those documents control.
+
+---
+
+Questions about this policy? Open an issue and ask.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,247 @@
+# Contributor License Agreement (CLA) for Zangetsu
+
+**Version 1** | **Last Updated: August 4, 2026**
+
+This Contributor License Agreement ("CLA") is between **Spyou** and each person or organization that submits a Contribution to the Zangetsu project.
+
+This CLA is intended to protect the Project, its maintainers, its users, and the integrity of the codebase — including giving Spyou the flexibility needed to develop and grow the Project over time — while allowing Contributors to retain ownership of their own work and operate under fair, predictable terms. **Zangetsu is, and will always remain, a free and open-source project** — see Section 3.1 for Spyou's permanent commitment on this.
+
+---
+
+## 1. Definitions
+
+- **"Project"** means Zangetsu and any official repositories, releases, documentation, build systems, assets, and related project infrastructure maintained by Spyou.
+- **"Contributor"** means any individual or organization submitting a Contribution.
+- **"You"** means the Contributor.
+- **"Contribution"** means any code, documentation, translations, artwork, design assets, bug fixes, patches, provider modules, extractor modules, configuration files, issue content, suggestions, or other material submitted to the Project in any form.
+- **"Submitted"** means delivered by pull request, patch, issue, message, email, form, or any other contribution channel accepted by the Project.
+
+---
+
+## 2. Ownership
+
+You keep ownership of your Contribution.
+
+Nothing in this CLA transfers copyright ownership from you to Spyou or to the Project unless a separate written assignment is signed.
+
+---
+
+## 3. License Grant to the Project
+
+By submitting a Contribution, you grant Spyou a **perpetual, worldwide, irrevocable, non-exclusive, royalty-free, fully paid-up, transferable, and sublicensable license** to use, reproduce, store, host, modify, adapt, translate, merge, publish, distribute, publicly display, publicly perform, and prepare derivative works from your Contribution, for any purpose connected to developing, operating, maintaining, testing, reviewing, documenting, distributing, and evolving the Project.
+
+This license includes, without limitation, the right for Spyou to:
+
+- include your Contribution in the Project, unmodified or modified;
+- distribute your Contribution as part of the Project under the Project's current license (GPLv3 with additional terms) or any future **open-source** license Spyou chooses to apply to the Project going forward, including switching to a different OSI-approved license if that ever better serves the Project;
+- sublicense your Contribution to third parties as part of the Project's ordinary open-source distribution, on terms consistent with an OSI-approved license and this Section;
+- use your Contribution in releases, previews, forks maintained by the Project, documentation, changelogs, demos, promotional material, and repository history; and
+- authorize others (including future maintainers or organizations under Section 17.4) to exercise the rights above, subject to the same restrictions in this Section.
+
+**3.1 Permanent Commitment to Free and Open Source.** Zangetsu is, and will remain, free to use, free to download, and free of paid or proprietary licensing. Spyou will not sell the Project, place it or any Contribution behind a paywall, offer a closed-source/proprietary version of it, or sublicense it on terms that are not themselves an OSI-approved open-source license. This commitment applies to the Project as a whole and to every Contribution submitted under this CLA, and it survives any transfer under Section 17.4 — a successor maintainer or organization inherits this same restriction and cannot waive it unilaterally.
+
+**What this does not do:** this grant does not transfer your copyright, does not stop you from using your own Contribution elsewhere (see Section 10), and does not change the license under which the *current* public repository is distributed — that remains GPLv3 with additional terms per Section 18. The sublicensable/transferable language exists to give Spyou practical flexibility (for example, moving the Project to a foundation, or switching to a different open-source license if GPLv3 ever stops fitting the Project's needs) — never to open a path toward a paid or closed version of Zangetsu.
+
+---
+
+## 4. Patent License
+
+If your Contribution includes patent-eligible subject matter, you grant to Spyou a perpetual, worldwide, irrevocable, non-exclusive, royalty-free, sublicensable patent license covering those patent claims that are necessarily infringed by your Contribution alone or by your Contribution as incorporated into the Project, sufficient to let Spyou exercise all the rights granted in Section 3.
+
+If you bring a patent claim against Spyou or the Project alleging that your Contribution or its use in the Project infringes your patent rights, then the patent license granted in this CLA for that Contribution ends automatically.
+
+---
+
+## 5. Contributor Promises
+
+By submitting a Contribution, you confirm that, to the best of your knowledge and belief:
+
+1. your Contribution is your original work, or you have the legal right to submit it under the terms of this CLA;
+2. you have not knowingly copied it from a source that you had no right to use;
+3. the Contribution does not knowingly infringe copyright, patent, trademark, trade secret, privacy, or other rights of a third party;
+4. if the Contribution includes third-party code, assets, data, or references, you have clearly identified them and confirmed that the license or permission is compatible with the Project;
+5. if AI tools were used to help create the Contribution, its use complies with the Project's AI Usage Policy (`AI_POLICY.md`);
+6. you are not violating any employment agreement, confidentiality obligation, client restriction, or other contract by submitting it;
+7. if you are submitting on behalf of an employer, company, client, or organization, you have authority to do so and that entity is bound by this CLA for that Contribution;
+8. you are legally able to enter into this CLA, or you have the permission of a parent or legal guardian if required by applicable law.
+
+You are not required to maintain, support, debug, update, or continue developing your Contribution after submission.
+
+---
+
+## 6. No Warranty
+
+Your Contribution is provided **"as is"** and **"as available"**.
+
+To the fullest extent permitted by law, you provide no warranties of any kind, express or implied, including warranties of merchantability, fitness for a particular purpose, title, and non-infringement.
+
+---
+
+## 7. Limited Contributor Liability
+
+You are responsible only for harm directly caused by fraud, intentional misconduct, knowing infringement, or a material breach of this CLA by you in connection with your own Contribution.
+
+You are not responsible for:
+- the Project as a whole;
+- other contributors' work;
+- forks;
+- downstream use;
+- third-party misuse;
+- how Spyou exercises the rights granted in Section 3 (including any relicensing decision); or
+- actions taken by Spyou or any third party outside the scope of your Contribution.
+
+---
+
+## 8. Indemnification
+
+If a third party brings a claim against Spyou or the Project because your Contribution was not actually yours to submit, knowingly infringed a third party's rights, or materially breached Section 5, then you agree to indemnify and hold harmless Spyou and the Project only to the extent that the claim is directly caused by your Contribution.
+
+This indemnity is limited to:
+- reasonable, documented legal costs;
+- settlements you approved in writing; or
+- damages finally awarded by a court or arbitrator with proper authority.
+
+This indemnity does not make you responsible for the Project generally, unrelated Project behavior, other people's contributions, or downstream forks and modifications you did not create or control.
+
+---
+
+## 9. Downstream Use, Forks, and Misuse
+
+Once a Contribution is included in the Project, it may be used, modified, reviewed, merged, distributed, sublicensed, and forked as described in Section 3 and under the Project's applicable license and project terms.
+
+However:
+- neither you nor Spyou is responsible for how unrelated third parties use or misuse the Project after release;
+- forks do not become official Project releases unless Spyou expressly approves them in writing;
+- use of the Zangetsu name, logo, branding, or official identity is not allowed unless Spyou gives written permission;
+- Spyou may reject, remove, or request changes to any Contribution that does not fit the Project's standards, security expectations, legal requirements, or code of conduct.
+
+---
+
+## 10. Contributor Freedom and Project Control
+
+Contributors remain free to:
+- use their own Contribution elsewhere, subject to the rights of others and applicable law;
+- reuse their own original work in other projects;
+- publish their own standalone versions of their work outside the Project;
+- keep attribution to themselves for their original authorship.
+
+Contributors do not gain:
+- control over the Project's release schedule;
+- the right to force a merge;
+- the right to override maintainer decisions;
+- the right to represent a fork as official;
+- the right to veto or approve licensing decisions made under Section 3; or
+- the right to use Project branding without permission.
+
+Spyou retains final authority over:
+- repository direction;
+- release inclusion;
+- contributor access;
+- moderation;
+- review standards;
+- naming;
+- official Project representation; and
+- licensing decisions for the Project as described in Section 3.
+
+---
+
+## 11. Acceptance
+
+A Contribution is not accepted unless the Contributor explicitly agrees to this CLA in the manner requested by the Project.
+
+Submitting a pull request, issue, patch, or message alone does not count as acceptance.
+
+**Bot acceptance line:**
+Reply to the CLA bot with:
+
+`I agree to the Zangetsu CLA v1`
+
+The Project may require a bot comment, checkbox, signed statement, digital signature, or other explicit confirmation before merging. If this CLA is updated to a new version, the version number in the acceptance line will change, and returning contributors will be asked to re-confirm.
+
+---
+
+## 12. Changes to This CLA
+
+Spyou may update this CLA from time to time.
+
+- New Contributions are governed by the version of the CLA in effect at the time they are submitted.
+- Previously submitted Contributions remain governed by the version that applied when they were submitted, unless the Contributor separately agrees in writing to a new version.
+- Material changes should be announced clearly in the repository or in a pinned project notice.
+
+---
+
+## 13. Conduct and Contribution Rules
+
+This CLA does not replace the Project's code of conduct, security policy, contribution guidelines, moderation rules, or repository rules.
+
+By contributing, you agree that you will not use the Project submission process to:
+- spam,
+- harass,
+- sabotage,
+- deceive,
+- inject malware,
+- submit obviously illegal content,
+- or deliberately disrupt the Project.
+
+Spyou may reject, close, or remove any Contribution or contributor access at any time for repeated failure to follow Project rules.
+
+---
+
+## 14. Copyright and Third-Party Material
+
+If your Contribution contains code, data, text, artwork, or other material from another source, you must clearly disclose that source and confirm the material is licensed or otherwise permitted for use in the Project.
+
+If the Project later discovers that a Contribution contains unauthorized material, Spyou may remove, replace, or reject that Contribution without liability to the Contributor except as required by applicable law.
+
+---
+
+## 15. Trademarks
+
+This CLA does not grant you any right to use the names, logos, marks, or branding of Zangetsu or Spyou except as needed to identify the Project accurately or credit your Contribution.
+
+Forks and derivative projects may not imply endorsement, sponsorship, affiliation, or official status without written permission from Spyou.
+
+---
+
+## 16. Governing Law
+
+This CLA is governed by the laws of **India**, without regard to conflict-of-law rules, unless another governing law is required by a written agreement signed by Spyou.
+
+Any dispute will first be handled through good-faith discussion. Nothing in this section limits any non-waivable rights or obligations under applicable law.
+
+---
+
+## 17. General Provisions
+
+### 17.1 Entire agreement
+This CLA, together with the Project's LICENSE, NOTICE file, contribution rules, AI Usage Policy, and code of conduct, is the entire agreement between you and Spyou regarding your Contribution.
+
+### 17.2 Severability
+If any part of this CLA is found unenforceable, the rest remains in effect, and the invalid part will be interpreted as narrowly as possible to preserve the intended protection.
+
+### 17.3 No waiver
+If Spyou does not enforce a provision on one occasion, that does not waive the right to enforce it later.
+
+### 17.4 Assignment
+Spyou may transfer the rights and obligations under this CLA — including the rights granted in Section 3 — to a successor maintainer, foundation, or organization, provided the successor is bound by substantially similar obligations toward Contributors.
+
+### 17.5 Survival
+Sections 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 14, 15, 16, and 17 survive termination, removal, or withdrawal from the Project.
+
+---
+
+## 18. Main License and Third-Party Notices
+
+The main Zangetsu repository is currently licensed under **GNU GPL version 3.0, with additional terms**, unless otherwise stated. Section 3 of this CLA gives Spyou the right to move the Project to a different **open-source** license in the future if needed — see Section 3.1, which permanently rules out any paid or proprietary licensing of the Project or its Contributions.
+
+Third-party components and their respective licenses are listed in the Project's `NOTICE.md`, `LICENSE-Apache-2.0.txt`, or other included license notices.
+
+Nothing in this CLA changes or overrides the licensing terms that apply to third-party components already included in the Project — Spyou's Section 3 rights extend only to Contributions submitted under this CLA, not to code the Project has incorporated under someone else's license (e.g. CloudStream, Aniyomi/Tachiyomi).
+
+---
+
+## 19. Contact
+
+Questions about this CLA may be raised through the Project issue tracker or by contacting **@Spyou**.
+
+**Thank you for contributing to Zangetsu.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing to Zangetsu
+
+First off, thanks for considering contributing to Zangetsu! Whether it's a bug fix, a new feature, a new provider, or just fixing a typo — it's appreciated.
+
+## Before You Start
+
+- Check [open issues](../../issues) to see if what you want to work on is already being tracked.
+- For anything bigger than a small fix (new features, big refactors, new providers), open an issue first to discuss the approach before writing code — saves everyone time.
+- By submitting a pull request, you agree to our [Contributor License Agreement](CLA.md). Please give it a quick read.
+- Zangetsu is licensed under **GPLv3 with additional terms** (see [`LICENSE`](LICENSE)) — your contributions will be distributed under those same terms.
+- Using AI tools to help write your Contribution? That's allowed — read [`AI_POLICY.md`](AI_POLICY.md) first for disclosure and quality expectations.
+- Third-party code Zangetsu incorporates (and its licenses) is documented in [`NOTICE.md`](NOTICE.md) — worth a skim if you're touching provider/extractor code.
+
+## Repo Structure
+
+This repo is the main Zangetsu app (Flutter/Dart, with native `android/` and `ios/` platform folders). A few things worth knowing before you dive in:
+
+- `lib/` — the main Dart application code
+- `providers/` — provider integrations bundled with the app
+- `extractors/` — logic for extracting playable streams from sources
+- `js_harness/` — JavaScript module execution used by providers
+- `assets/` — icons, splash screens, and other static assets
+- `test/` — tests
+
+**Note:** additional/community content sources live in a separate repo, [zangetsu-providers](https://github.com/Spyou/zangetsu-providers). If your contribution is a new content source rather than a core app change, check there first — it may be the better place for it.
+
+## Setting Up Your Dev Environment
+
+1. Fork the repo and clone your fork:
+   ```bash
+   git clone https://github.com/Spyou/Zangetsu.git
+   cd Zangetsu
+   ```
+2. Make sure you have the **Flutter SDK** installed (check `pubspec.yaml` / `.metadata` for the version this project targets).
+3. Get dependencies:
+   ```bash
+   flutter pub get
+   ```
+4. Run the app on a connected device/emulator:
+   ```bash
+   flutter run
+   ```
+5. Create a new branch for your change:
+   ```bash
+   git checkout -b fix/short-description
+   ```
+
+## Making Changes
+
+- Keep pull requests focused — one fix or feature per PR is easier to review than a bundle of unrelated changes.
+- Match the existing code style already in the file you're editing.
+- Add or update tests under `test/` where it makes sense.
+- Update relevant documentation/comments if your change affects behavior.
+- **If your PR adds a new dependency, or incorporates code/assets derived from another project, update [`NOTICE.md`](NOTICE.md) in the same PR.** This isn't optional — PRs that introduce undocumented third-party code will be asked to add the attribution before merging.
+
+## Code Analysis
+
+This project uses `analysis_options.yaml` to enforce Dart/Flutter lint rules. Before opening a PR, run:
+
+```bash
+flutter analyze
+```
+
+and fix anything flagged. If you're touching platform-specific code (`android/`, `ios/`), also make sure the native build still compiles cleanly.
+
+## Commit Messages
+
+Write clear, descriptive commit messages. We loosely follow this format:
+
+```
+type: short summary
+
+Optional longer description if needed.
+```
+
+Where `type` is one of: `fix`, `feat`, `docs`, `refactor`, `chore`, `test`.
+
+Example: `fix: correct resume position not saving on episode change`
+
+## Submitting a Pull Request
+
+1. Push your branch and open a PR against `main`.
+2. Fill out the PR template with what changed and why.
+3. Link any related issues (e.g. `Closes #42`).
+4. Make sure CI checks (build, analyze, tests) pass.
+5. Be responsive to review feedback — most PRs go through a round or two of comments before merging.
+
+## Reporting Bugs
+
+Open an issue with:
+- What you expected to happen vs. what actually happened
+- Steps to reproduce
+- Device/OS and app version
+- Screenshots, logs, or a stack trace if relevant
+
+## Adding or Fixing a Provider/Extractor
+
+If you're contributing a provider or extractor:
+- Only submit sources you have the right to interact with — see Section 5 of the [CLA](CLA.md).
+- Keep provider logic isolated from core app logic where possible.
+- Test that search, browsing, and playback all work end-to-end before submitting.
+- Note any rate limits, region restrictions, or fragility (e.g. sources that change their site structure often) in your PR description.
+
+## Code of Conduct
+
+Be respectful. Disagreements about code are fine; personal attacks aren't. Maintainers reserve the right to close issues/PRs or block contributors who don't engage in good faith.
+
+---
+
+Questions? Open an issue or start a discussion — happy to help you get oriented.

--- a/LICENSE
+++ b/LICENSE
@@ -620,24 +620,71 @@ copy of the Program in return for a fee.
 
                      END OF TERMS AND CONDITIONS
 
-            How to Apply These Terms to Your New Programs
+      ADDITIONAL TERMS UNDER GPLv3 SECTION 7 — SPECIFIC TO ZANGETSU
 
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
+The following additional terms apply to Zangetsu, as permitted under
+GPLv3 Section 7. These terms supplement, and do not replace, the GNU
+General Public License v3 above.
 
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
+  A. Trademark and Name Restriction (Section 7(e))
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+  This License does not grant any right to use the name "Zangetsu",
+its associated logo, icon, or branding, in connection with any
+modified or unmodified version of the Program, except as required for
+reasonable and factual attribution of the Program's origin. In
+particular, a modified version may not be distributed, published, or
+advertised under the name "Zangetsu" or any confusingly similar name
+without the prior written permission of the copyright holder.
+
+  B. No Misrepresentation of Origin (Section 7(c))
+
+  You may not represent a modified version of the Program as being the
+official Zangetsu project, or as being endorsed, certified, or
+supported by its original author(s), unless you have received their
+express permission to do so. Any modified version you convey must be
+marked in a reasonably prominent way (e.g., in the app name, splash
+screen, "About" section, or repository README) as a modified,
+unofficial, or forked version, distinct from the original Zangetsu.
+
+  C. Attribution Preservation (Section 7(b))
+
+  Any copy or modified version of the Program that you convey must
+retain a clearly visible statement crediting the original Zangetsu
+project and its author(s), including a link to the original source
+repository, in at least one of: the application's "About" or
+"Credits" screen, the repository's README, or the NOTICE file.
+
+  D. Publicity Limitation (Section 7(d))
+
+  You may not use the name of the original author(s) of Zangetsu to
+endorse or promote products or services derived from the Program
+without their prior written consent.
+
+  E. Indemnification for Contractual Liability (Section 7(f))
+
+  If you convey the Program, or a modified version of it, under terms
+that contractually impose liability on recipients toward you (for
+example, a paid support agreement, warranty, or SLA you offer), you
+agree to indemnify the original author(s) of Zangetsu for any
+liability those contractual assumptions impose on them, to the extent
+such liability arises from your added terms rather than from the
+Program itself.
+
+  These additional terms are severable from, and do not modify, the
+GNU General Public License v3 terms above. If any additional term
+above is held unenforceable, the remaining additional terms and the
+underlying GPLv3 license remain in full effect.
+
+                  How to Apply This License to Zangetsu
+
+    Zangetsu
+    Copyright (C) 2026  Spyou
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+    (at your option) any later version, subject to the additional terms
+    above.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -647,28 +694,4 @@ the "copyright" line and a pointer to where the full notice is found.
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-Also add information on how to contact you by electronic and paper mail.
-
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.
+Contact: @Spyou (https://github.com/Spyou)

--- a/LICENSE-Apache-2.0.txt
+++ b/LICENSE-Apache-2.0.txt
@@ -200,3 +200,21 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+NOTE FOR THIS REPOSITORY (Zangetsu):
+
+This file is included because Zangetsu incorporates and distributes certain
+third-party code licensed under the Apache License, Version 2.0, including
+code derived from Aniyomi/Tachiyomi located under:
+
+    android/app/src/main/kotlin/com/spyou/watch_app/aniyomi/
+
+The applicable original copyright, attribution, and license notices for
+third-party code are retained in the relevant source files and/or documented
+in NOTICE.md.
+
+This file reproduces the Apache License, Version 2.0, and does not constitute
+a claim by Zangetsu or its author over copyright in third-party code.
+
+See NOTICE.md for the applicable third-party attribution and licensing
+information.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -32,3 +32,22 @@ Aniyomi / Tachiyomi
 
 Other dependencies (Flutter/Dart packages and Android libraries) are used under
 their respective open-source licenses; refer to each package for details.
+
+────────────────────────────────────────────────────────────────────────────
+Keeping this file current
+────────────────────────────────────────────────────────────────────────────
+
+Any pull request that adds a new third-party dependency, incorporates code
+derived from another project, or bundles another project's assets must update
+this file in the same PR — see CONTRIBUTING.md. This file is treated as the
+authoritative record of what's bundled and under what terms; if it's out of
+date, that's considered a bug, not a formality.
+
+────────────────────────────────────────────────────────────────────────────
+Reporting a concern
+────────────────────────────────────────────────────────────────────────────
+
+If you believe this project incorporates third-party code, assets, or content
+without proper attribution or in violation of its license, please open an
+issue or contact Spyou directly (https://github.com/Spyou) so it can be
+corrected or removed.


### PR DESCRIPTION
## What this adds

This PR lays the legal and contributor-facing foundation for Zangetsu:

- **`LICENSE`** — GPLv3 with additional terms protecting the Zangetsu name/branding and locking in that the project will always stay free and open-source (see Section 3.1 of the CLA for the matching commitment)
- **`LICENSE-Apache-2.0.txt`** — required alongside `LICENSE` since parts of the app are derived from Aniyomi/Tachiyomi (Apache-2.0)
- **`NOTICE.md`** — documents third-party code currently bundled (CloudStream, Aniyomi/Tachiyomi) and requires future PRs to keep it updated
- **`CLA.md`** — contributor agreement covering license grant, patent grant, liability limits (capped to a contributor's own work), and indemnification scope
- **`CONTRIBUTING.md`** — dev setup, PR process, and provider/extractor contribution guidelines
- **`AI_POLICY.md`** — AI-assisted contributions are allowed with disclosure; human review/testing still required
- **`.github/workflows/CLA.yml`** — first-time contributor greetings