### PR TITLE
fix(tv): let the remote leave the sign-in text fields

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,8 +8,8 @@ plugins {
     // Version scoped here (not in root settings) so it can't clash with the
     // serialization plugin version a Flutter plugin module pins for itself.
     id("org.jetbrains.kotlin.plugin.serialization") version "2.2.20"
-    // Firebase Analytics — consumes android/app/google-services.json.
-    id("com.google.gms.google-services")
+    // Applied at the bottom only when google-services.json is present (gitignored).
+    id("com.google.gms.google-services") apply false
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -273,4 +273,13 @@ dependencies {
     // whose own code disables it on TV by default "because of crashes"). Never
     // touches the phone player or the Flutter platform-view player.
     implementation("io.github.anilbeesetti:nextlib-media3ext:1.7.1-0.9.0")
+}
+
+// google-services.json is gitignored (see android/.gitignore). Dart already
+// no-ops Analytics/FCM when Firebase.initializeApp() fails, so a missing file
+// must not fail the Gradle build — same idea as falling back when
+// key.properties is absent. Drop the real file at android/app/google-services.json
+// (Firebase console → Project settings → Android app) to turn Firebase on.
+if (file("google-services.json").exists()) {
+    apply(plugin = "com.google.gms.google-services")
 }

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,26 +4,8 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-
-    <application>
-        <!-- Debug-only launcher entry, so `flutter run` works.
-             The tool finds the app to start by scanning the manifest for an
-             <activity> carrying MAIN + LAUNCHER — and it does not look at
-             <activity-alias> at all. Our phone launcher lives on the aliases
-             (that's how the app-icon picker switches icons), so the release
-             manifest has no such <activity> and `flutter run` fails with
-             "package identifier or launch activity not found".
-             Adding LAUNCHER to MainActivity for real would put a permanent
-             second icon on the launcher and break the picker, so it goes here
-             instead: the manifest merger only folds this in for debug builds,
-             leaving the release manifest exactly as it was.
-             The cost is a duplicate icon while developing. Debug only — no
-             release anyone installs is affected. -->
-        <activity android:name=".MainActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-        </activity>
-    </application>
+    <!-- Phone MAIN+LAUNCHER lives on MainActivity in the main manifest so
+         `flutter run` can parse it before any APK exists. Release strips that
+         filter (src/release/AndroidManifest.xml) so the activity-aliases stay
+         the only home-screen icons. -->
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,14 +62,24 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
-            <!-- The phone LAUNCHER entry lives on the activity-aliases below, so
-                 the user can switch the home-screen icon (Settings → Appearance).
-                 It is deliberately NOT here: an activity and its alias would both
-                 appear in the launcher.
+            <!-- Flutter's `flutter run` / IDE launch parses THIS file (not the
+                 merged APK) and requires an <activity> with MAIN + LAUNCHER. It
+                 ignores <activity-alias>, so putting the phone launcher only on
+                 the aliases below makes the tool fail with "package identifier
+                 or launch activity not found" whenever no built APK is sitting
+                 in build/ yet (first run, after clean, Cursor/VS Code debug).
+
+                 The aliases remain the real home-screen entries (Settings →
+                 Appearance flips them). src/release/AndroidManifest.xml strips
+                 this filter so a shipped APK does not grow a second icon.
 
                  LEANBACK stays on the activity itself. TV has no icon picker and
                  uses android:banner, and moving this would risk the app losing
                  its home entry on a TV entirely. -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -4,16 +4,6 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-
-    <application>
-        <!-- Same launcher entry as the debug source set, so `flutter run
-             --profile` starts too. See src/debug/AndroidManifest.xml for why
-             this can't live in the real manifest. Profile builds only. -->
-        <activity android:name=".MainActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-        </activity>
-    </application>
+    <!-- See src/debug/AndroidManifest.xml — the Flutter-tool launcher filter
+         is in the main manifest, not here. -->
 </manifest>

--- a/android/app/src/release/AndroidManifest.xml
+++ b/android/app/src/release/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <!-- Drop the Flutter-tool MAIN+LAUNCHER filter from MainActivity. Release
+         users must only see the activity-alias icons (the Appearance picker
+         enables exactly one). Debug/profile keep the filter so `flutter run`
+         can find a launch activity in the source manifest. -->
+    <application>
+        <activity android:name=".MainActivity">
+            <intent-filter tools:node="remove">
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/lib/core/tv/tv_text_field.dart
+++ b/lib/core/tv/tv_text_field.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_text.dart';
+import 'tv_keys.dart';
+
+/// A [TextField] that stays D-pad navigable on Android TV.
+///
+/// Autofocusing a normal [TextField] raises the leanback IME, which swallows
+/// D-pad events so the remote cannot move to the next control. [EditableText]
+/// also eats arrow keys for cursor movement even when the IME is closed, and
+/// Select/OK does not re-show a dismissed keyboard.
+///
+/// This widget:
+///  * lands focus without opening the IME (`readOnly` until OK)
+///  * routes D-pad arrows to [FocusNode.focusInDirection] while not editing
+///  * shows the keyboard on OK/Select
+///
+/// Use anywhere on TV in place of a bare [TextField].
+class TvTextField extends StatefulWidget {
+  const TvTextField({
+    super.key,
+    this.controller,
+    this.focusNode,
+    this.decoration,
+    this.autofocus = false,
+    this.enabled = true,
+    this.obscureText = false,
+    this.obscuringCharacter = '•',
+    this.keyboardType,
+    this.textInputAction,
+    this.textCapitalization = TextCapitalization.none,
+    this.autocorrect = true,
+    this.enableSuggestions = true,
+    this.inputFormatters,
+    this.maxLines = 1,
+    this.minLines,
+    this.maxLength,
+    this.style,
+    this.cursorColor,
+    this.onChanged,
+    this.onSubmitted,
+  });
+
+  /// Optional external focus node. [TvTextField] still owns D-pad / OK handling
+  /// on this node; pass one only when a parent needs to [FocusNode.requestFocus]
+  /// or listen for focus changes.
+  final FocusNode? focusNode;
+
+  final TextEditingController? controller;
+  final InputDecoration? decoration;
+  final bool autofocus;
+  final bool enabled;
+  final bool obscureText;
+  final String obscuringCharacter;
+  final TextInputType? keyboardType;
+  final TextInputAction? textInputAction;
+  final TextCapitalization textCapitalization;
+  final bool autocorrect;
+  final bool enableSuggestions;
+  final List<TextInputFormatter>? inputFormatters;
+  final int? maxLines;
+  final int? minLines;
+  final int? maxLength;
+  final TextStyle? style;
+  final Color? cursorColor;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+
+  @override
+  State<TvTextField> createState() => _TvTextFieldState();
+}
+
+class _TvTextFieldState extends State<TvTextField> {
+  late final FocusNode _focus;
+  late final bool _ownsFocus;
+  bool _editing = false;
+
+  bool get _singleLine => (widget.maxLines ?? 1) == 1;
+
+  @override
+  void initState() {
+    super.initState();
+    final external = widget.focusNode;
+    if (external != null) {
+      _ownsFocus = false;
+      _focus = external;
+      _focus.onKeyEvent = _onKey;
+    } else {
+      _ownsFocus = true;
+      _focus = FocusNode(onKeyEvent: _onKey);
+    }
+    _focus.addListener(_onFocusChange);
+  }
+
+  @override
+  void dispose() {
+    _focus.removeListener(_onFocusChange);
+    if (_ownsFocus) {
+      _focus.dispose();
+    } else {
+      _focus.onKeyEvent = null;
+    }
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    if (!mounted) return;
+    if (_focus.hasFocus) {
+      Scrollable.ensureVisible(
+        context,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 200),
+      );
+    } else if (_editing) {
+      setState(() => _editing = false);
+    }
+  }
+
+  KeyEventResult _onKey(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent) return KeyEventResult.ignored;
+    final key = event.logicalKey;
+
+    if (okKeys.contains(key)) {
+      if (widget.enabled) _showIme();
+      return KeyEventResult.handled;
+    }
+
+    final direction = _directionFor(key);
+    if (direction == null) return KeyEventResult.ignored;
+
+    // While editing a multi-line field, leave arrows to the caret / IME.
+    final stealArrows =
+        !_editing ||
+        (_singleLine &&
+            (direction == TraversalDirection.up ||
+                direction == TraversalDirection.down));
+    if (!stealArrows) return KeyEventResult.ignored;
+
+    if (node.focusInDirection(direction)) {
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  TraversalDirection? _directionFor(LogicalKeyboardKey key) {
+    if (key == LogicalKeyboardKey.arrowDown) return TraversalDirection.down;
+    if (key == LogicalKeyboardKey.arrowUp) return TraversalDirection.up;
+    if (key == LogicalKeyboardKey.arrowLeft) return TraversalDirection.left;
+    if (key == LogicalKeyboardKey.arrowRight) return TraversalDirection.right;
+    return null;
+  }
+
+  void _showIme() {
+    if (!_editing) setState(() => _editing = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (!_focus.hasFocus) _focus.requestFocus();
+      SystemChannels.textInput.invokeMethod('TextInput.show');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: widget.controller,
+      focusNode: _focus,
+      autofocus: widget.autofocus,
+      enabled: widget.enabled,
+      readOnly: !_editing,
+      showCursor: _editing,
+      obscureText: widget.obscureText,
+      obscuringCharacter: widget.obscuringCharacter,
+      keyboardType: widget.keyboardType,
+      textInputAction: widget.textInputAction,
+      textCapitalization: widget.textCapitalization,
+      autocorrect: widget.autocorrect,
+      enableSuggestions: widget.enableSuggestions,
+      inputFormatters: widget.inputFormatters,
+      maxLines: widget.obscureText ? 1 : widget.maxLines,
+      minLines: widget.minLines,
+      maxLength: widget.maxLength,
+      onChanged: widget.onChanged,
+      onSubmitted: widget.onSubmitted,
+      onTap: widget.enabled ? _showIme : null,
+      style:
+          widget.style ?? AppText.body.copyWith(color: AppColors.textPrimary),
+      cursorColor: widget.cursorColor ?? AppColors.accent,
+      decoration: widget.decoration,
+    );
+  }
+}

--- a/lib/features/auth/auth_screens_tv.dart
+++ b/lib/features/auth/auth_screens_tv.dart
@@ -6,6 +6,7 @@ import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_text.dart';
 import '../../core/tv/tv_back_button.dart';
 import '../../core/tv/tv_focusable.dart';
+import '../../core/tv/tv_text_field.dart';
 import 'auth_cubit.dart';
 import 'tv_pair_screen.dart';
 
@@ -13,10 +14,9 @@ import 'tv_pair_screen.dart';
 // Login (TV)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// TV Login: email + password TextFields with the email field autofocused so
-/// the Android TV leanback keyboard appears on entry. The login button is a
-/// [TvFocusable] so OK/Enter submits via the same [AuthCubit.login] call as
-/// the phone path. D-pad DOWN moves email → password → button.
+/// TV Login: email + password fields. Email is autofocused for D-pad landing
+/// but the keyboard stays closed until OK, so DOWN can reach password, Log in,
+/// and "Sign in with your phone". OK on a field raises the leanback IME.
 class LoginScreenTv extends StatefulWidget {
   const LoginScreenTv({super.key});
   @override
@@ -35,31 +35,26 @@ class _LoginScreenTvState extends State<LoginScreenTv> {
   }
 
   Future<void> _submit(BuildContext context) async {
-    final ok = await context.read<AuthCubit>().login(
-      _email.text.trim(),
-      _password.text,
-    );
+    final ok = await context.read<AuthCubit>().login(_email.text.trim(), _password.text);
     if (ok && context.mounted) Navigator.of(context).pop();
   }
 
-  InputDecoration _fieldDecoration(String hint, IconData icon) =>
-      InputDecoration(
-        hintText: hint,
-        hintStyle: AppText.body.copyWith(color: AppColors.textTertiary),
-        prefixIcon: Icon(icon, color: AppColors.textTertiary, size: 20),
-        filled: true,
-        fillColor: AppColors.surface,
-        contentPadding:
-            const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: const BorderSide(color: AppColors.hairline, width: 0.5),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: BorderSide(color: AppColors.accent, width: 2),
-        ),
-      );
+  InputDecoration _fieldDecoration(String hint, IconData icon) => InputDecoration(
+    hintText: hint,
+    hintStyle: AppText.body.copyWith(color: AppColors.textTertiary),
+    prefixIcon: Icon(icon, color: AppColors.textTertiary, size: 20),
+    filled: true,
+    fillColor: AppColors.surface,
+    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+    enabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(color: AppColors.hairline, width: 0.5),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: BorderSide(color: AppColors.accent, width: 2),
+    ),
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -73,159 +68,129 @@ class _LoginScreenTvState extends State<LoginScreenTv> {
                 width: 480,
                 child: ListView(
                   shrinkWrap: true,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 48, vertical: 48),
+                  padding: const EdgeInsets.symmetric(horizontal: 48, vertical: 48),
                   children: [
                     Text('Welcome back', style: AppText.largeTitle),
-                const SizedBox(height: 8),
-                Text(
-                  'Sign in to sync your list across devices.',
-                  style: AppText.body,
-                ),
-                const SizedBox(height: 32),
+                    const SizedBox(height: 8),
+                    Text('Sign in to sync your list across devices.', style: AppText.body),
+                    const SizedBox(height: 32),
 
-                // Email — autofocus=true triggers the Android TV leanback
-                // on-screen keyboard as soon as this screen is displayed.
-                TextField(
-                  controller: _email,
-                  autofocus: true,
-                  keyboardType: TextInputType.emailAddress,
-                  textInputAction: TextInputAction.next,
-                  style:
-                      AppText.body.copyWith(color: AppColors.textPrimary),
-                  cursorColor: AppColors.accent,
-                  decoration: _fieldDecoration('Email', Icons.mail_outline),
-                ),
-                const SizedBox(height: 14),
+                    // Email — focused on entry so the remote has a starting point,
+                    // but IME stays closed until OK (see [TvTextField]).
+                    TvTextField(
+                      controller: _email,
+                      autofocus: true,
+                      keyboardType: TextInputType.emailAddress,
+                      textInputAction: TextInputAction.next,
+                      decoration: _fieldDecoration('Email', Icons.mail_outline),
+                    ),
+                    const SizedBox(height: 14),
 
-                // Password — textInputAction.done → calls _submit on TV keyboard OK.
-                TextField(
-                  controller: _password,
-                  obscureText: true,
-                  textInputAction: TextInputAction.done,
-                  onSubmitted: (_) => _submit(context),
-                  style:
-                      AppText.body.copyWith(color: AppColors.textPrimary),
-                  cursorColor: AppColors.accent,
-                  decoration:
-                      _fieldDecoration('Password', Icons.lock_outline),
-                ),
-                const SizedBox(height: 24),
+                    // Password — IME Done / onSubmitted calls _submit.
+                    TvTextField(
+                      controller: _password,
+                      obscureText: true,
+                      textInputAction: TextInputAction.done,
+                      onSubmitted: (_) => _submit(context),
+                      decoration: _fieldDecoration('Password', Icons.lock_outline),
+                    ),
+                    const SizedBox(height: 24),
 
-                BlocBuilder<AuthCubit, AuthState>(
-                  builder: (context, state) {
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        if (state.error != null) ...[
-                          Text(
-                            state.error!,
-                            style: AppText.caption
-                                .copyWith(color: AppColors.accent),
-                          ),
-                          const SizedBox(height: 10),
-                        ],
-                        if (state.busy)
-                          Center(
-                            child: SizedBox(
-                              width: 28,
-                              height: 28,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2.4,
-                                color: AppColors.accent,
-                              ),
-                            ),
-                          )
-                        else
-                          // D-pad OK on this TvFocusable submits the login form —
-                          // identical to the phone's "Log in" PrimaryButton.
-                          TvFocusable(
-                            onTap: () => _submit(context),
-                            child: SizedBox(
-                              height: 56,
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(
-                                  color: Colors.white,
-                                  borderRadius: BorderRadius.circular(14),
+                    BlocBuilder<AuthCubit, AuthState>(
+                      builder: (context, state) {
+                        return Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            if (state.error != null) ...[
+                              Text(state.error!, style: AppText.caption.copyWith(color: AppColors.accent)),
+                              const SizedBox(height: 10),
+                            ],
+                            if (state.busy)
+                              Center(
+                                child: SizedBox(
+                                  width: 28,
+                                  height: 28,
+                                  child: CircularProgressIndicator(strokeWidth: 2.4, color: AppColors.accent),
                                 ),
-                                child: Center(
-                                  child: Text(
-                                    'Log in',
-                                    style: AppText.button
-                                        .copyWith(color: Colors.black),
+                              )
+                            else
+                              // D-pad OK on this TvFocusable submits the login form —
+                              // identical to the phone's "Log in" PrimaryButton.
+                              TvFocusable(
+                                onTap: () => _submit(context),
+                                child: SizedBox(
+                                  height: 56,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      color: Colors.white,
+                                      borderRadius: BorderRadius.circular(14),
+                                    ),
+                                    child: Center(
+                                      child: Text('Log in', style: AppText.button.copyWith(color: Colors.black)),
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                          ),
-                      ],
-                    );
-                  },
-                ),
-
-                const SizedBox(height: 14),
-                // Sign in without typing: pair with the already-signed-in phone.
-                TvFocusable(
-                  onTap: () async {
-                    final paired = await Navigator.of(context).push<bool>(
-                      MaterialPageRoute<bool>(
-                          builder: (_) => const TvPairScreen()),
-                    );
-                    // Paired via phone → the TV is signed in now; pop this login
-                    // screen too so we land straight back in the app instead of
-                    // lingering on the form.
-                    if (paired == true && context.mounted) {
-                      Navigator.of(context).pop();
-                    }
-                  },
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: Text.rich(
-                      TextSpan(
-                        text: 'Typing is a pain?  ',
-                        style: AppText.caption,
-                        children: [
-                          TextSpan(
-                            text: 'Sign in with your phone',
-                            style: AppText.caption.copyWith(
-                              color: AppColors.accent,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                        ],
-                      ),
-                      textAlign: TextAlign.center,
+                          ],
+                        );
+                      },
                     ),
-                  ),
-                ),
 
-                const SizedBox(height: 8),
-                TvFocusable(
-                  onTap: () => Navigator.of(context).pushReplacement(
-                    MaterialPageRoute(
-                        builder: (_) => const SignupScreenTv()),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: Text.rich(
-                      TextSpan(
-                        text: "Don't have an account?  ",
-                        style: AppText.caption,
-                        children: [
+                    const SizedBox(height: 14),
+                    // Sign in without typing: pair with the already-signed-in phone.
+                    TvFocusable(
+                      onTap: () async {
+                        final paired = await Navigator.of(
+                          context,
+                        ).push<bool>(MaterialPageRoute<bool>(builder: (_) => const TvPairScreen()));
+                        // Paired via phone → the TV is signed in now; pop this login
+                        // screen too so we land straight back in the app instead of
+                        // lingering on the form.
+                        if (paired == true && context.mounted) {
+                          Navigator.of(context).pop();
+                        }
+                      },
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        child: Text.rich(
                           TextSpan(
-                            text: 'Sign up',
-                            style: AppText.caption.copyWith(
-                              color: AppColors.accent,
-                              fontWeight: FontWeight.w700,
-                            ),
+                            text: 'Typing is a pain?  ',
+                            style: AppText.caption,
+                            children: [
+                              TextSpan(
+                                text: 'Sign in with your phone',
+                                style: AppText.caption.copyWith(color: AppColors.accent, fontWeight: FontWeight.w700),
+                              ),
+                            ],
                           ),
-                        ],
+                          textAlign: TextAlign.center,
+                        ),
                       ),
-                      textAlign: TextAlign.center,
                     ),
-                  ),
-                ),
-              ],
+
+                    const SizedBox(height: 8),
+                    TvFocusable(
+                      onTap: () => Navigator.of(
+                        context,
+                      ).pushReplacement(MaterialPageRoute(builder: (_) => const SignupScreenTv())),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        child: Text.rich(
+                          TextSpan(
+                            text: "Don't have an account?  ",
+                            style: AppText.caption,
+                            children: [
+                              TextSpan(
+                                text: 'Sign up',
+                                style: AppText.caption.copyWith(color: AppColors.accent, fontWeight: FontWeight.w700),
+                              ),
+                            ],
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
@@ -241,9 +206,9 @@ class _LoginScreenTvState extends State<LoginScreenTv> {
 // Signup (TV)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// TV Signup: name, email, and password TextFields with the name field
-/// autofocused. Avatar selection is omitted on TV (gallery picker is not
-/// remote-friendly). Submit calls [AuthCubit.signUp] — same logic as the phone.
+/// TV Signup: name, email, and password fields. Name is autofocused for D-pad
+/// landing; OK on a field raises the keyboard. Avatar selection is omitted on
+/// TV (gallery picker is not remote-friendly). Submit calls [AuthCubit.signUp].
 class SignupScreenTv extends StatefulWidget {
   const SignupScreenTv({super.key});
   @override
@@ -267,38 +232,29 @@ class _SignupScreenTvState extends State<SignupScreenTv> {
     if (_password.text.length < 8) {
       ScaffoldMessenger.of(context)
         ..clearSnackBars()
-        ..showSnackBar(
-          const SnackBar(
-              content: Text('Password must be at least 8 characters')),
-        );
+        ..showSnackBar(const SnackBar(content: Text('Password must be at least 8 characters')));
       return;
     }
-    final ok = await context.read<AuthCubit>().signUp(
-      _name.text.trim(),
-      _email.text.trim(),
-      _password.text,
-    );
+    final ok = await context.read<AuthCubit>().signUp(_name.text.trim(), _email.text.trim(), _password.text);
     if (ok && context.mounted) Navigator.of(context).pop();
   }
 
-  InputDecoration _fieldDecoration(String hint, IconData icon) =>
-      InputDecoration(
-        hintText: hint,
-        hintStyle: AppText.body.copyWith(color: AppColors.textTertiary),
-        prefixIcon: Icon(icon, color: AppColors.textTertiary, size: 20),
-        filled: true,
-        fillColor: AppColors.surface,
-        contentPadding:
-            const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: const BorderSide(color: AppColors.hairline, width: 0.5),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: BorderSide(color: AppColors.accent, width: 2),
-        ),
-      );
+  InputDecoration _fieldDecoration(String hint, IconData icon) => InputDecoration(
+    hintText: hint,
+    hintStyle: AppText.body.copyWith(color: AppColors.textTertiary),
+    prefixIcon: Icon(icon, color: AppColors.textTertiary, size: 20),
+    filled: true,
+    fillColor: AppColors.surface,
+    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+    enabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: const BorderSide(color: AppColors.hairline, width: 0.5),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: BorderSide(color: AppColors.accent, width: 2),
+    ),
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -312,129 +268,102 @@ class _SignupScreenTvState extends State<SignupScreenTv> {
                 width: 480,
                 child: ListView(
                   shrinkWrap: true,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 48, vertical: 48),
+                  padding: const EdgeInsets.symmetric(horizontal: 48, vertical: 48),
                   children: [
                     Text('Create account', style: AppText.largeTitle),
-                const SizedBox(height: 8),
-                Text(
-                  'Save your list and continue watching anywhere.',
-                  style: AppText.body,
-                ),
-                const SizedBox(height: 32),
+                    const SizedBox(height: 8),
+                    Text('Save your list and continue watching anywhere.', style: AppText.body),
+                    const SizedBox(height: 32),
 
-                // Name — autofocused so the TV keyboard appears on entry.
-                TextField(
-                  controller: _name,
-                  autofocus: true,
-                  textInputAction: TextInputAction.next,
-                  style:
-                      AppText.body.copyWith(color: AppColors.textPrimary),
-                  cursorColor: AppColors.accent,
-                  decoration: _fieldDecoration('Name', Icons.person_outline),
-                ),
-                const SizedBox(height: 14),
+                    TvTextField(
+                      controller: _name,
+                      autofocus: true,
+                      textInputAction: TextInputAction.next,
+                      decoration: _fieldDecoration('Name', Icons.person_outline),
+                    ),
+                    const SizedBox(height: 14),
 
-                TextField(
-                  controller: _email,
-                  keyboardType: TextInputType.emailAddress,
-                  textInputAction: TextInputAction.next,
-                  style:
-                      AppText.body.copyWith(color: AppColors.textPrimary),
-                  cursorColor: AppColors.accent,
-                  decoration: _fieldDecoration('Email', Icons.mail_outline),
-                ),
-                const SizedBox(height: 14),
+                    TvTextField(
+                      controller: _email,
+                      keyboardType: TextInputType.emailAddress,
+                      textInputAction: TextInputAction.next,
+                      decoration: _fieldDecoration('Email', Icons.mail_outline),
+                    ),
+                    const SizedBox(height: 14),
 
-                TextField(
-                  controller: _password,
-                  obscureText: true,
-                  textInputAction: TextInputAction.done,
-                  onSubmitted: (_) => _submit(context),
-                  style:
-                      AppText.body.copyWith(color: AppColors.textPrimary),
-                  cursorColor: AppColors.accent,
-                  decoration: _fieldDecoration(
-                      'Password (8+ characters)', Icons.lock_outline),
-                ),
-                const SizedBox(height: 24),
+                    TvTextField(
+                      controller: _password,
+                      obscureText: true,
+                      textInputAction: TextInputAction.done,
+                      onSubmitted: (_) => _submit(context),
+                      decoration: _fieldDecoration('Password (8+ characters)', Icons.lock_outline),
+                    ),
+                    const SizedBox(height: 24),
 
-                BlocBuilder<AuthCubit, AuthState>(
-                  builder: (context, state) {
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        if (state.error != null) ...[
-                          Text(
-                            state.error!,
-                            style: AppText.caption
-                                .copyWith(color: AppColors.accent),
-                          ),
-                          const SizedBox(height: 10),
-                        ],
-                        if (state.busy)
-                          Center(
-                            child: SizedBox(
-                              width: 28,
-                              height: 28,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2.4,
-                                color: AppColors.accent,
-                              ),
-                            ),
-                          )
-                        else
-                          TvFocusable(
-                            onTap: () => _submit(context),
-                            child: SizedBox(
-                              height: 56,
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(
-                                  color: Colors.white,
-                                  borderRadius: BorderRadius.circular(14),
+                    BlocBuilder<AuthCubit, AuthState>(
+                      builder: (context, state) {
+                        return Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            if (state.error != null) ...[
+                              Text(state.error!, style: AppText.caption.copyWith(color: AppColors.accent)),
+                              const SizedBox(height: 10),
+                            ],
+                            if (state.busy)
+                              Center(
+                                child: SizedBox(
+                                  width: 28,
+                                  height: 28,
+                                  child: CircularProgressIndicator(strokeWidth: 2.4, color: AppColors.accent),
                                 ),
-                                child: Center(
-                                  child: Text(
-                                    'Create account',
-                                    style: AppText.button
-                                        .copyWith(color: Colors.black),
+                              )
+                            else
+                              TvFocusable(
+                                onTap: () => _submit(context),
+                                child: SizedBox(
+                                  height: 56,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      color: Colors.white,
+                                      borderRadius: BorderRadius.circular(14),
+                                    ),
+                                    child: Center(
+                                      child: Text(
+                                        'Create account',
+                                        style: AppText.button.copyWith(color: Colors.black),
+                                      ),
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                          ),
-                      ],
-                    );
-                  },
-                ),
-
-                const SizedBox(height: 16),
-                TvFocusable(
-                  onTap: () => Navigator.of(context).pushReplacement(
-                    MaterialPageRoute(
-                        builder: (_) => const LoginScreenTv()),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: Text.rich(
-                      TextSpan(
-                        text: 'Already have an account?  ',
-                        style: AppText.caption,
-                        children: [
-                          TextSpan(
-                            text: 'Log in',
-                            style: AppText.caption.copyWith(
-                              color: AppColors.accent,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                        ],
-                      ),
-                      textAlign: TextAlign.center,
+                          ],
+                        );
+                      },
                     ),
-                  ),
-                ),
-              ],
+
+                    const SizedBox(height: 16),
+                    TvFocusable(
+                      onTap: () => Navigator.of(
+                        context,
+                      ).pushReplacement(MaterialPageRoute(builder: (_) => const LoginScreenTv())),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        child: Text.rich(
+                          TextSpan(
+                            text: 'Already have an account?  ',
+                            style: AppText.caption,
+                            children: [
+                              TextSpan(
+                                text: 'Log in',
+                                style: AppText.caption.copyWith(color: AppColors.accent, fontWeight: FontWeight.w700),
+                              ),
+                            ],
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
@@ -468,84 +397,68 @@ class ProfileScreenTv extends StatelessWidget {
                 if (!state.isLoggedIn) {
                   return const Center(child: Text('Not signed in'));
                 }
-            return Center(
-              child: SizedBox(
-                width: 520,
-                child: ListView(
-                  shrinkWrap: true,
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 48, vertical: 48),
-                  children: [
-                    // Avatar
-                    Center(
-                      child: CircleAvatar(
-                        radius: 56,
-                        backgroundColor: AppColors.surface2,
-                        backgroundImage: state.avatarUrl != null
-                            ? CachedNetworkImageProvider(state.avatarUrl!)
-                            : null,
-                        child: state.avatarUrl == null
-                            ? Text(
-                                state.displayName.isNotEmpty
-                                    ? state.displayName[0].toUpperCase()
-                                    : '?',
-                                style: AppText.largeTitle,
-                              )
-                            : null,
-                      ),
-                    ),
-                    const SizedBox(height: 20),
-
-                    Center(
-                        child: Text(state.displayName,
-                            style: AppText.title)),
-                    const SizedBox(height: 6),
-                    Center(
-                      child: Text(
-                        state.user?.email ?? '',
-                        style: AppText.caption,
-                      ),
-                    ),
-                    const SizedBox(height: 40),
-
-                    // Logout
-                    TvFocusable(
-                      autofocus: true,
-                      onTap: () {
-                        context.read<AuthCubit>().logout();
-                        Navigator.of(context).pop();
-                      },
-                      child: SizedBox(
-                        height: 56,
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            color: const Color(0x1AFFFFFF),
-                            borderRadius: BorderRadius.circular(14),
-                            border: Border.all(
-                                color: AppColors.hairline, width: 0.5),
+                return Center(
+                  child: SizedBox(
+                    width: 520,
+                    child: ListView(
+                      shrinkWrap: true,
+                      padding: const EdgeInsets.symmetric(horizontal: 48, vertical: 48),
+                      children: [
+                        // Avatar
+                        Center(
+                          child: CircleAvatar(
+                            radius: 56,
+                            backgroundColor: AppColors.surface2,
+                            backgroundImage: state.avatarUrl != null
+                                ? CachedNetworkImageProvider(state.avatarUrl!)
+                                : null,
+                            child: state.avatarUrl == null
+                                ? Text(
+                                    state.displayName.isNotEmpty ? state.displayName[0].toUpperCase() : '?',
+                                    style: AppText.largeTitle,
+                                  )
+                                : null,
                           ),
-                          child: Center(
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const Icon(Icons.logout_rounded,
-                                    color: AppColors.textPrimary, size: 20),
-                                const SizedBox(width: 8),
-                                Text(
-                                  'Log out',
-                                  style: AppText.button.copyWith(
-                                      color: AppColors.textPrimary),
+                        ),
+                        const SizedBox(height: 20),
+
+                        Center(child: Text(state.displayName, style: AppText.title)),
+                        const SizedBox(height: 6),
+                        Center(child: Text(state.user?.email ?? '', style: AppText.caption)),
+                        const SizedBox(height: 40),
+
+                        // Logout
+                        TvFocusable(
+                          autofocus: true,
+                          onTap: () {
+                            context.read<AuthCubit>().logout();
+                            Navigator.of(context).pop();
+                          },
+                          child: SizedBox(
+                            height: 56,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(
+                                color: const Color(0x1AFFFFFF),
+                                borderRadius: BorderRadius.circular(14),
+                                border: Border.all(color: AppColors.hairline, width: 0.5),
+                              ),
+                              child: Center(
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Icon(Icons.logout_rounded, color: AppColors.textPrimary, size: 20),
+                                    const SizedBox(width: 8),
+                                    Text('Log out', style: AppText.button.copyWith(color: AppColors.textPrimary)),
+                                  ],
                                 ),
-                              ],
+                              ),
                             ),
                           ),
                         ),
-                      ),
+                      ],
                     ),
-                  ],
-                ),
-              ),
-            );
+                  ),
+                );
               },
             ),
           ), // SafeArea


### PR DESCRIPTION
The leanback IME and EditableText swallowed D-pad on email/password, so OK did not show the keyboard and Down never reached Sign in with your phone. TvTextField keeps IME closed until OK and routes arrows to focus traversal.

<!--
Target `main`. Keep PRs focused — one fix or feature per PR reviews far faster
than a bundle. See CONTRIBUTING.md if you haven't already.
-->

## What changed
Fixes Android TV not allowing the user to navigate the Welcome Back / Auth page. Created a new TvTextField that doesn't allow the Android TV keyboard to swallow Remote events.

<!-- What does this do, and why? If it fixes a bug, what was going wrong? -->

Closes #19 

## How you tested it
Wirelessly debugged on One 4k Streamer and Google TV Emulator

<!-- Device/emulator and Android version, or "iOS simulator". Say what you
actually exercised — "played an episode end to end", "browsed + searched two
sources". "Builds fine" isn't testing. -->

## Checklist

- [ x] `flutter analyze` is clean
- [ x] `flutter test` passes **- some failed but not related to this task**
- [ x] Native build still compiles, if I touched `android/` or `iOS/`
- [ x] I've read and agree to the [CLA](../CLA.md)
- [ x] Used AI tooling? Disclosed per [`AI_POLICY.md`](../AI_POLICY.md) - yes, used Cursor to brainstorm solution, manually tested and challenged AI to make the most minimal and efficient fix. 