### PR TITLE
fix(tv): pairing QR uses https so Camera can open it

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -71,5 +71,24 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<!-- Custom-scheme hand-off from https://zangetsu.online/pair/ (and
+	     share / tracker OAuth). Without this, Safari's zangetsu:// redirect
+	     after scanning the TV QR never reaches the app. Flutter's own
+	     deep-link handler is off so app_links receives the URI. -->
+	<key>FlutterDeepLinkingEnabled</key>
+	<false/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.spyou.watchApp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>zangetsu</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/lib/core/environment.dart
+++ b/lib/core/environment.dart
@@ -10,11 +10,14 @@ class Environment {
   // Appwrite project id/endpoint above. Override with --dart-define if a
   // build needs a different project (e.g. staging).
   static const String supabaseUrl = String.fromEnvironment(
-      'SUPABASE_URL', defaultValue: 'https://eogwzrlfoercfwcfwlmv.supabase.co');
+    'SUPABASE_URL',
+    defaultValue: 'https://eogwzrlfoercfwcfwlmv.supabase.co',
+  );
   static const String supabaseAnonKey = String.fromEnvironment(
-      'SUPABASE_ANON_KEY',
-      defaultValue:
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVvZ3d6cmxmb2VyY2Z3Y2Z3bG12Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODQzNjgzODIsImV4cCI6MjA5OTk0NDM4Mn0.qr-nHnB9vb7BodP55XJ9-6Rwp__eOGCS6txhLiuWVZw');
+    'SUPABASE_ANON_KEY',
+    defaultValue:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVvZ3d6cmxmb2VyY2Z3Y2Z3bG12Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODQzNjgzODIsImV4cCI6MjA5OTk0NDM4Mn0.qr-nHnB9vb7BodP55XJ9-6Rwp__eOGCS6txhLiuWVZw',
+  );
 
   /// Where Appwrite sends the password-recovery link. Appwrite appends
   /// Password-reset landing. Supabase now drives reset (via the auth `site_url`,
@@ -30,10 +33,16 @@ class Environment {
   /// must be an Appwrite Web platform (already added for the reset page).
   static const String siteOpenUrl = '$siteBaseUrl/open/';
 
+  /// TV pairing QR. iPhone Camera only treats http(s) as a link, so the TV
+  /// encodes this URL (not `zangetsu://pair`). The page is the phone login +
+  /// approve flow — same `pair-tv` approve the Android app uses.
+  static const String sitePairUrl = '$siteBaseUrl/pair/';
+
   /// The "open" page redirects to `zangetsu://open?…`; an installed app catches
   /// it (see [OpenLinkService] + the Android manifest intent-filter).
   static const String openLinkScheme = trackerRedirectScheme; // 'zangetsu'
   static const String openLinkHost = 'open';
+  static const String pairLinkHost = 'pair';
 
   // Provisioned backend ids (see docs / setup).
   static const String databaseId = 'main';
@@ -55,23 +64,18 @@ class Environment {
   // AniList — implicit grant (token in URL fragment, 1-year, no secret).
   static const String anilistClientId = '43052';
   static const String anilistRedirectHost = 'anilist-auth';
-  static String get anilistRedirectUri =>
-      '$trackerRedirectScheme://$anilistRedirectHost';
+  static String get anilistRedirectUri => '$trackerRedirectScheme://$anilistRedirectHost';
 
   // MyAnimeList — OAuth2 PKCE (plain), no client secret.
   static const String malClientId = 'ac006943589381143c4c4e54eac93a89';
   static const String malRedirectHost = 'mal-auth';
-  static String get malRedirectUri =>
-      '$trackerRedirectScheme://$malRedirectHost';
+  static String get malRedirectUri => '$trackerRedirectScheme://$malRedirectHost';
 
   // Simkl — OAuth2 authorization-code (needs the secret to exchange the code).
-  static const String simklClientId =
-      '8b847b09206ccdb0b3de4cc1293d6dd7d355821f5c179c57315da8ba9030eb53';
-  static const String simklClientSecret =
-      '34ba8e5ac7c8a5c27926dfdf78205e5b913de9928361cb5a243558239298c96d';
+  static const String simklClientId = '8b847b09206ccdb0b3de4cc1293d6dd7d355821f5c179c57315da8ba9030eb53';
+  static const String simklClientSecret = '34ba8e5ac7c8a5c27926dfdf78205e5b913de9928361cb5a243558239298c96d';
   static const String simklRedirectHost = 'simkl-auth';
-  static String get simklRedirectUri =>
-      '$trackerRedirectScheme://$simklRedirectHost';
+  static String get simklRedirectUri => '$trackerRedirectScheme://$simklRedirectHost';
 
   // Back-compat alias (older AniList code referenced this name).
   static const String anilistRedirectScheme = trackerRedirectScheme;

--- a/lib/core/share/open_link_service.dart
+++ b/lib/core/share/open_link_service.dart
@@ -9,15 +9,13 @@ import '../di/injector.dart';
 import '../models/media_item.dart';
 import '../repository/source_repository.dart';
 import '../ui/global_messenger.dart';
+import 'pair_link.dart';
 import 'share_link.dart';
 
-/// Listens for incoming `zangetsu://open?…` share links and opens the shared
-/// title's Detail on its source — or, when that source isn't installed on this
-/// device, tells the user instead of failing silently.
-///
-/// Additive + isolated: it shares the app-wide [AppLinks] stream with the
-/// tracker OAuth listeners and simply ignores any link that isn't
-/// `zangetsu://open` ([ShareLink.parse] returns null), so nothing else changes.
+/// Listens for incoming share links (`zangetsu://open?…`) and pairing links
+/// (`https://zangetsu.online/pair/?…` or `zangetsu://pair?…`) and opens the
+/// matching screen. Tracker OAuth listeners share the same [AppLinks] stream
+/// and ignore anything they don't own.
 class OpenLinkService {
   OpenLinkService() {
     _sub = _appLinks.uriLinkStream.listen(_onLink, onError: (_) {});
@@ -31,14 +29,14 @@ class OpenLinkService {
   StreamSubscription<Uri>? _sub;
 
   void _onLink(Uri uri) {
-    // zangetsu://pair?code=CODE — a TV pairing QR scanned on the phone.
-    if (uri.host == 'pair') {
-      final code = uri.queryParameters['code'];
-      final nonce = uri.queryParameters['nonce'];
-      if (uri.queryParameters['trackers'] == '1') {
-        _openSendTrackers(code, nonce); // Flow B — added in Task 11
+    // HTTPS /pair/?code=… (iPhone Camera) or zangetsu://pair?code=… (site
+    // redirect / Android custom-scheme). Same payload either way.
+    final pair = PairLink.parse(uri);
+    if (pair != null) {
+      if (pair.trackers) {
+        _openSendTrackers(pair.code, pair.nonce);
       } else {
-        _openPair(code, nonce);
+        _openPair(pair.code, pair.nonce);
       }
       return;
     }

--- a/lib/core/share/pair_link.dart
+++ b/lib/core/share/pair_link.dart
@@ -1,0 +1,76 @@
+import '../environment.dart';
+
+/// Encodes the TV pairing QR as an HTTPS URL (iPhone Camera rejects custom
+/// schemes with "No usable data found") and parses incoming pair links from
+/// either the website or the `zangetsu://pair` redirect it fires.
+class PairLink {
+  const PairLink({this.code, this.nonce, this.trackers = false});
+
+  final String? code;
+  final String? nonce;
+
+  /// When true this is the trackers-only QR (Flow B), not account sign-in.
+  final bool trackers;
+
+  /// Payload printed in the TV QR. An http(s) URL so iPhone Camera treats it
+  /// as a link instead of "No usable data found".
+  static String qrData({
+    required String code,
+    String? nonce,
+    bool trackers = false,
+  }) {
+    return Uri.parse(Environment.sitePairUrl).replace(
+      queryParameters: _query(code: code, nonce: nonce, trackers: trackers),
+    ).toString();
+  }
+
+  /// Custom-scheme link the `/pair/` landing page (and Android intent-filters)
+  /// hand off to [OpenLinkService].
+  static String deepLink({
+    required String code,
+    String? nonce,
+    bool trackers = false,
+  }) {
+    return Uri(
+      scheme: Environment.trackerRedirectScheme,
+      host: Environment.pairLinkHost,
+      queryParameters: _query(code: code, nonce: nonce, trackers: trackers),
+    ).toString();
+  }
+
+  static Map<String, String> _query({
+    required String code,
+    String? nonce,
+    bool trackers = false,
+  }) =>
+      {
+        'code': code,
+        if (nonce != null && nonce.isNotEmpty) 'nonce': nonce,
+        if (trackers) 'trackers': '1',
+      };
+
+  /// Accepts `zangetsu://pair?…` and the configured [Environment.sitePairUrl].
+  static PairLink? parse(Uri uri) {
+    if (!_isPairUri(uri)) return null;
+    final q = uri.queryParameters;
+    return PairLink(
+      code: q['code'],
+      nonce: q['nonce'],
+      trackers: q['trackers'] == '1',
+    );
+  }
+
+  static bool _isPairUri(Uri uri) {
+    if (uri.scheme == Environment.trackerRedirectScheme &&
+        uri.host == Environment.pairLinkHost) {
+      return true;
+    }
+    final site = Uri.parse(Environment.sitePairUrl);
+    if ((uri.scheme == 'http' || uri.scheme == 'https') && uri.host == site.host) {
+      final path = uri.path.replaceAll(RegExp(r'/+$'), '');
+      final sitePath = site.path.replaceAll(RegExp(r'/+$'), '');
+      return path == sitePath;
+    }
+    return false;
+  }
+}

--- a/lib/features/auth/pair_tv_screen.dart
+++ b/lib/features/auth/pair_tv_screen.dart
@@ -11,8 +11,9 @@ import 'auth_cubit.dart';
 import 'tv_pairing_service.dart';
 
 /// Phone: approve a TV pairing. Enter the code shown on the TV (or arrive here
-/// via the `zangetsu://pair` QR deep-link), confirm the device, and sign the TV
-/// into this account. Requires the phone to be signed in.
+/// via the pairing QR — `https://zangetsu.online/pair/?code=…`, forwarded to
+/// `zangetsu://pair`), confirm the device, and sign the TV into this account.
+/// Requires the phone to be signed in.
 class PairTvScreen extends StatefulWidget {
   const PairTvScreen({super.key, this.initialCode, this.nonce});
   final String? initialCode;

--- a/lib/features/auth/tv_pair_screen.dart
+++ b/lib/features/auth/tv_pair_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../core/di/injector.dart';
+import '../../core/share/pair_link.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_text.dart';
 import '../../core/tracker/relay/tracker_blob.dart';
@@ -160,8 +161,9 @@ class _TvPairScreenState extends State<TvPairScreen> {
               borderRadius: BorderRadius.circular(16),
             ),
             child: QrImageView(
-              data: 'zangetsu://pair?code=$_code'
-                  '${_nonce != null ? '&nonce=$_nonce' : ''}',
+              // https://… — iPhone Camera rejects custom schemes with
+              // "No usable data found". The /pair/ page is the web login.
+              data: PairLink.qrData(code: _code ?? '', nonce: _nonce),
               size: 220,
               gapless: true,
             ),

--- a/lib/features/auth/tv_tracker_connect_screen.dart
+++ b/lib/features/auth/tv_tracker_connect_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../core/di/injector.dart';
+import '../../core/share/pair_link.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_text.dart';
 import '../../core/tracker/relay/tracker_blob.dart';
@@ -133,12 +134,16 @@ class _TvTrackerConnectScreenState extends State<TvTrackerConnectScreen> {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      // QR 1 — the existing phone-app relay. UNCHANGED: an
-                      // installed Zangetsu app catches this deep link, approves,
-                      // and relays its own $_label session to this TV.
+                      // QR 1 — phone-app relay. HTTPS so iPhone Camera treats
+                      // it as a link (custom schemes show "No usable data
+                      // found"). The /pair/ page then opens the app, which
+                      // approves and relays this $_label session to the TV.
                       _qrOption(
-                        data:
-                            'zangetsu://pair?code=$_code&nonce=$_nonce&trackers=1',
+                        data: PairLink.qrData(
+                          code: _code!,
+                          nonce: _nonce,
+                          trackers: true,
+                        ),
                         title: 'Have the app?',
                         subtitle: 'Open Zangetsu on your\nphone and scan',
                       ),

--- a/test/core/share/pair_link_test.dart
+++ b/test/core/share/pair_link_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:watch_app/core/environment.dart';
+import 'package:watch_app/core/share/pair_link.dart';
+
+void main() {
+  const code = 'ABCD2345';
+  const nonce = 'n_s3creTN0nceValue_________pad';
+  final site = Uri.parse(Environment.sitePairUrl);
+
+  test('qrData is an http(s) URL so iPhone Camera treats it as a link', () {
+    final data = PairLink.qrData(code: code, nonce: nonce);
+    final uri = Uri.parse(data);
+
+    expect(uri.scheme, anyOf('http', 'https'));
+    expect(uri.host, site.host);
+    expect(uri.path, site.path);
+    expect(uri.queryParameters['code'], code);
+    expect(uri.queryParameters['nonce'], nonce);
+    expect(uri.queryParameters.containsKey('trackers'), isFalse);
+  });
+
+  test('qrData omits nonce when absent and flags the trackers-only flow', () {
+    final data = PairLink.qrData(code: code, trackers: true);
+    final uri = Uri.parse(data);
+
+    expect(uri.scheme, anyOf('http', 'https'));
+    expect(uri.queryParameters['code'], code);
+    expect(uri.queryParameters.containsKey('nonce'), isFalse);
+    expect(uri.queryParameters['trackers'], '1');
+  });
+
+  test('parse round-trips the QR URL and the zangetsu:// deep link', () {
+    final web = Uri.parse(PairLink.qrData(code: code, nonce: nonce));
+    final fromWeb = PairLink.parse(web);
+    expect(fromWeb, isNotNull);
+    expect(fromWeb!.code, code);
+    expect(fromWeb.nonce, nonce);
+    expect(fromWeb.trackers, isFalse);
+
+    final deep = Uri.parse(PairLink.deepLink(code: code, nonce: nonce, trackers: true));
+    expect(deep.scheme, 'zangetsu');
+    expect(deep.host, 'pair');
+    final fromDeep = PairLink.parse(deep);
+    expect(fromDeep, isNotNull);
+    expect(fromDeep!.code, code);
+    expect(fromDeep.nonce, nonce);
+    expect(fromDeep.trackers, isTrue);
+  });
+
+  test('parse ignores unrelated links', () {
+    expect(PairLink.parse(Uri.parse('zangetsu://open?s=x&u=y')), isNull);
+    expect(PairLink.parse(Uri.parse('https://zangetsu.online/open/?s=x&u=y')), isNull);
+    expect(PairLink.parse(Uri.parse('https://example.com/pair/?code=$code')), isNull);
+  });
+}


### PR DESCRIPTION
iPhone Camera rejects `zangetsu://pair` with "No usable data found", so the TV QR never opened a pairing flow. The QR now encodes `https://zangetsu.online/pair/?code=…`, which Camera treats as a link. Android can still open the app from that page via `intent://` / `zangetsu://pair`.

<!--
Target `main`. Keep PRs focused — one fix or feature per PR reviews far faster
than a bundle. See CONTRIBUTING.md if you haven't already.
-->

## What changed

TV sign-in and tracker-connect QRs now print an https `/pair/` URL instead of a custom scheme. `PairLink` encodes that URL and parses both it and `zangetsu://pair` so `OpenLinkService` lands on the same phone screen. iOS registers the `zangetsu` URL scheme for the hand-off.

The phone login + approve page lives at `/pair/` on [Zangetsu-Site](https://github.com/Spyou/Zangetsu-Site) (web login for iPhone, Open in Zangetsu + optional 8-box code entry). That page needs to be deployed for production Camera scans to work.

Closes #21

## How you tested it

- `flutter test test/core/share/pair_link_test.dart` — pass
- `flutter analyze` on the touched Dart files — clean
- Android phone: scanned the TV QR (LAN `/pair/` during testing). Page loaded with the code; **Open in Zangetsu** is shown on Android. `/pair/` with no query shows eight boxes to type the TV code.
- Not re-tested on a physical iPhone against production `zangetsu.online/pair/` yet — that needs the site page live. The QR payload is http(s), which is what Camera requires.

[https://github.com/Spyou/Zangetsu-Site/pull/1](https://github.com/Spyou/Zangetsu-Site/pull/1
)
## Checklist

- [x] `flutter analyze` is clean
- [x] `flutter test` passes — ran `pair_link` tests for this change; other suite failures, if any, are unrelated
- [x] Native build still compiles, if I touched `android/` or `ios/` — Info.plist only (URL types)
- [x] I've read and agree to the [CLA](../CLA.md)
- [x] New dependency or third-party code? [`NOTICE.md`](../NOTICE.md) updated in this PR — no new dependency (existing `flutter_volume_controller` bump to 2.0.2 is on this branch so debug assemble still registers the plugin)
- [x] Used AI tooling? Disclosed per [`AI_POLICY.md`](../AI_POLICY.md)

AI assistance: used Cursor to draft PairLink, the QR wiring, and the `/pair/` page. Reviewed and tested on Android; challenged the approach so Camera gets https and the app still receives `zangetsu://pair`.

## Screenshots

Before: iPhone Camera → "No usable data found" on the TV pairing QR.

After: QR is `https://zangetsu.online/pair/?code=…` → Camera opens the page (login / Open in Zangetsu).

Made with [Cursor](https://cursor.com)