### PR TITLE
fix(android): bump flutter_volume_controller to 2.0.2

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -719,10 +719,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_volume_controller
-      sha256: "78297fd48ce6330d39a11a4c1ae219a3256249f99dec34cfbe9323d2cbb5ebb9"
+      sha256: f9ba12aa17880c1ee3e1668f14eefbc6704e2fed90ed0b2ca97b7dee71133240
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   flutter_web_auth_2:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -109,7 +109,7 @@ dependencies:
   # CloudStream-style volume swipe: the right-half drag drives the REAL Android
   # system media volume for 0–100% (then mpv `af=volume` boosts beyond 100%),
   # exactly like CloudStream's slider. System UI is suppressed (we draw our HUD).
-  flutter_volume_controller: ^2.0.1
+  flutter_volume_controller: ^2.0.2
   # Offline downloads — true background downloads with a progress notification,
   # pause/resume, and move-to-shared-storage (public Downloads folder).
   # Pinned to 9.5.5 — 9.5.7's Android/Kotlin code fails to compile here


### PR DESCRIPTION
2.0.1 no longer ships FlutterVolumeControllerPlugin, so assembleDebug failed when GeneratedPluginRegistrant tried to register it.