### PR TITLE
fix(tv): show a dialog when an episode fails to load

### DIFF
--- a/lib/core/tv/tv_load_error_dialog.dart
+++ b/lib/core/tv/tv_load_error_dialog.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_text.dart';
+import 'tv_focusable.dart';
+
+/// TV-sized alert when an episode stream fails to resolve or start.
+///
+/// Ten-foot UI: large type, wide card, and a single autofocused OK so the
+/// remote can dismiss it without hunting. Phone layouts never call this.
+Future<void> showTvPlaybackLoadError(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    barrierColor: Colors.black54,
+    builder: (ctx) => Dialog(
+      backgroundColor: AppColors.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 96, vertical: 64),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minWidth: 560, maxWidth: 680),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(40, 36, 40, 28),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                "Couldn't load this episode",
+                style: AppText.largeTitle.copyWith(fontSize: 28),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'There was an issue loading this content. If this continues, '
+                'try changing sources.',
+                style: AppText.body.copyWith(
+                  fontSize: 18,
+                  height: 1.45,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+              const SizedBox(height: 32),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TvFocusable(
+                  scale: 1.0,
+                  autofocus: true,
+                  variant: TvFocusVariant.pill,
+                  onTap: () => Navigator.pop(ctx),
+                  semanticLabel: 'OK',
+                  builder: (focused) => DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: focused ? Colors.white : AppColors.accent,
+                      borderRadius: BorderRadius.circular(24),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 36,
+                        vertical: 14,
+                      ),
+                      child: Text(
+                        'OK',
+                        style: AppText.headline.copyWith(
+                          fontSize: 18,
+                          color: focused ? Colors.black : Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/features/detail/detail_screen.dart
+++ b/lib/features/detail/detail_screen.dart
@@ -57,6 +57,7 @@ import '../../core/theme/app_text.dart';
 import '../../core/trailer/trailer_service.dart';
 import '../../core/tv/tv_back_button.dart';
 import '../../core/tv/tv_focusable.dart';
+import '../../core/tv/tv_load_error_dialog.dart';
 import '../../core/aniyomi/aniyomi_image_provider.dart';
 import '../../core/mihon/mihon_image_provider.dart';
 import '../../core/ui/badge.dart';

--- a/lib/features/detail/detail_screen_tv.dart
+++ b/lib/features/detail/detail_screen_tv.dart
@@ -186,12 +186,12 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
   }
 
   // ── Player launch (mirrors _DetailViewState._openPlayer exactly) ──────────
-  void _openPlayer(
+  Future<void> _openPlayer(
     List<Episode> episodes,
     int index,
     MediaDetail detail,
     String category,
-  ) {
+  ) async {
     final available = <String>[
       if ((detail.subCount ?? 0) > 0) 'sub',
       if ((detail.dubCount ?? 0) > 0) 'dub',
@@ -211,7 +211,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     // Beta: fully-native TV player (real-window SurfaceView) for TVs that
     // black-screen the Flutter platform-view player. Opt-in; phone unaffected.
     if (sl<PlaybackPrefs>().nativeTvPlayer) {
-      TvNativePlayer.play(
+      final started = await TvNativePlayer.play(
         sourceId: widget.item.sourceId,
         episodes: episodes,
         startIndex: index,
@@ -226,6 +226,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
         malId: detail.malId ?? widget.item.malId,
         scrobbleTitle: detail.type == ProviderType.anime ? detail.title : null,
       );
+      if (!started && mounted) await showTvPlaybackLoadError(context);
       return;
     }
     // TV default: native ExoPlayer via a Flutter platform view — smooth even at

--- a/lib/features/player/tv_exo_player_screen.dart
+++ b/lib/features/player/tv_exo_player_screen.dart
@@ -33,6 +33,7 @@ import '../../core/torrent/torrent_util.dart';
 import '../../core/tracker/tracker_hub.dart';
 import '../../core/tv/tv_focusable.dart';
 import '../../core/tv/tv_keys.dart';
+import '../../core/tv/tv_load_error_dialog.dart';
 import '../../core/ui/subtitle_language_picker.dart';
 import 'tv_exo_controller.dart';
 import 'tv_track_menu.dart';
@@ -277,10 +278,12 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     );
   }
 
+  bool _loadErrorDialogOpen = false;
+
   Future<void> _loadEpisode() async {
     final ep = _ep;
     if (ep == null) {
-      setState(() => _error = 'No episode to play.');
+      await _onEpisodeLoadFailed('No episode to play.');
       return;
     }
     _lastSavedMs = 0;
@@ -291,15 +294,28 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
       final prefer = _category == 'dub' ? AudioKind.dub : AudioKind.sub;
       final src = pickDefault(sources, prefer: prefer);
       if (src == null) {
-        setState(() => _error = 'No playable source.');
+        await _onEpisodeLoadFailed('No playable source.');
         return;
       }
       _sources = sources;
       final mark = widget.resume.get(widget.sourceId, _resumeShowId, ep.id);
       await _open(src, seekToMs: mark?.position.inMilliseconds ?? 0);
     } catch (e) {
-      setState(() => _error = 'Could not load this episode.');
+      await _onEpisodeLoadFailed('Could not load this episode.');
     }
+  }
+
+  Future<void> _onEpisodeLoadFailed(String message) async {
+    if (!mounted) return;
+    setState(() => _error = message);
+    if (_loadErrorDialogOpen) return;
+    _loadErrorDialogOpen = true;
+    await showTvPlaybackLoadError(context);
+    _loadErrorDialogOpen = false;
+    if (!mounted) return;
+    // First-open failure: leave the empty player so the user is back on
+    // Detail. Keep this screen if a previous episode was already playing.
+    if (_activeSource == null) Navigator.of(context).maybePop();
   }
 
   /// Loads [src] into the player (with any side-loaded subtitles) and arms a

--- a/lib/features/player/tv_native_player.dart
+++ b/lib/features/player/tv_native_player.dart
@@ -55,7 +55,10 @@ class TvNativePlayer {
   static ResumeStore? _resume;
   static String? _torrentId; // active torrent stream (stopped on switch/close)
 
-  static Future<void> play({
+  /// Returns `false` when the episode could not be resolved or started (no
+  /// sources, torrent blocked, etc.). Callers should surface that to the user;
+  /// this method itself has no UI.
+  static Future<bool> play({
     required String sourceId,
     required List<Episode> episodes,
     required int startIndex,
@@ -70,7 +73,7 @@ class TvNativePlayer {
     int? malId,
     String? scrobbleTitle,
   }) async {
-    if (startIndex < 0 || startIndex >= episodes.length) return;
+    if (startIndex < 0 || startIndex >= episodes.length) return false;
 
     _resolve = resolveSources;
     _episodes = episodes;
@@ -91,9 +94,9 @@ class TvNativePlayer {
 
     final ep = episodes[startIndex];
     final src = await _resolveSource(ep);
-    if (src == null) return;
+    if (src == null) return false;
     final playUrl = await _playableUrl(src.url);
-    if (playUrl == null) return; // torrent failed / Wi-Fi-only
+    if (playUrl == null) return false; // torrent failed / Wi-Fi-only
     final mark = resume.get(sourceId, _showId, ep.id);
 
     // Full subtitle style, computed the SAME way as the Flutter PlatformView TV
@@ -154,6 +157,7 @@ class TvNativePlayer {
     // mounted underneath and won't re-fire it, so we must (mirrors
     // PlayerController.close()).
     _announceBrowsing();
+    return true;
   }
 
   /// Handles native→Dart calls while the player is on screen.

--- a/test/core/tv/tv_load_error_dialog_test.dart
+++ b/test/core/tv/tv_load_error_dialog_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:watch_app/core/tv/tv_load_error_dialog.dart';
+
+void main() {
+  testWidgets('TV load-error dialog shows the change-sources message',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () => showTvPlaybackLoadError(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Couldn't load this episode"), findsOneWidget);
+    expect(
+      find.textContaining('try changing sources'),
+      findsOneWidget,
+    );
+    expect(find.text('OK'), findsOneWidget);
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(find.text("Couldn't load this episode"), findsNothing);
+  });
+}


### PR DESCRIPTION
## What changed

TV’s default native player resolved streams before launching, then returned with no UI when AllAnime (or any source) came back empty. Tapping an episode looked like a no-op.

This adds a remote-sized alert on that failure, plus the same dialog on the Flutter TV player so an episode tap always explains what happened and suggests changing sources if it continues.

Closes #26

## How you tested it

- Widget test: `flutter test test/core/tv/tv_load_error_dialog_test.dart` (dialog copy + OK dismiss)
- Logic reviewed against the native player’s silent `return` on empty sources (the path in the original logs)

Not re-tested on a TV/emulator in this PR.

## Checklist

- [x] `flutter analyze` is clean
- [x] `flutter test` passes
- [ ] Native build still compiles, if I touched `android/` or `ios/`
- [x] I've read and agree to the [CLA](../CLA.md)
- [ ] New dependency or third-party code? [`NOTICE.md`](../NOTICE.md) updated in this PR
- [x] Used AI tooling? Disclosed per [`AI_POLICY.md`](../AI_POLICY.md)

AI assistance: Cursor drafted the TV dialog and the native-player `bool` return; I scoped it to episode-tap TV paths only (no home/downloads, no volume-controller bump).


Demo:
<img width="1680" height="943" alt="CleanShot 2026-08-18 at 13 06 01" src="https://github.com/user-attachments/assets/35100de3-30d0-44c6-b750-b36ff84698a3" />
