### PR TITLE
fix(tv): open My List status options on a held OK

### DIFF
--- a/lib/core/tv/tv_focusable.dart
+++ b/lib/core/tv/tv_focusable.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../theme/app_text.dart';
@@ -22,12 +25,17 @@ enum TvFocusVariant {
 /// Wraps any tappable so it is D-pad focusable on TV: highlights while focused,
 /// scrolls itself into view, and invokes [onTap] on OK/Enter/center. Use
 /// everywhere on TV layouts instead of a bare GestureDetector/InkWell.
+///
+/// When [onLongPress] is set, OK is held to distinguish tap vs long-press
+/// (remote KeyDown is no longer treated as an instant tap). Buttons without
+/// a long-press handler stay immediate on KeyDown.
 class TvFocusable extends StatefulWidget {
   const TvFocusable({
     super.key,
     this.child,
     this.builder,
     required this.onTap,
+    this.onLongPress,
     this.autofocus = false,
     this.scale = 1.08,
     this.focusLabel,
@@ -53,6 +61,11 @@ class TvFocusable extends StatefulWidget {
   final Widget Function(bool focused)? builder;
 
   final VoidCallback onTap;
+
+  /// Optional long-press. On the remote this is a held OK/Select (same
+  /// timeout as a touch long-press). Null keeps the snappy KeyDown tap.
+  final VoidCallback? onLongPress;
+
   final bool autofocus;
   final double scale;
 
@@ -80,6 +93,20 @@ class TvFocusable extends StatefulWidget {
 class _TvFocusableState extends State<TvFocusable> {
   bool _focused = false;
   int _lastActivateMs = 0;
+  Timer? _longPressTimer;
+  bool _okHeld = false;
+  bool _longPressFired = false;
+
+  @override
+  void dispose() {
+    _cancelLongPressTimer();
+    super.dispose();
+  }
+
+  void _cancelLongPressTimer() {
+    _longPressTimer?.cancel();
+    _longPressTimer = null;
+  }
 
   // Single activation path for both the D-pad OK key and the accessibility
   // "click" (Semantics.onTap), deduped within a short window so a press that
@@ -91,16 +118,54 @@ class _TvFocusableState extends State<TvFocusable> {
     widget.onTap();
   }
 
+  void _fireLongPress() {
+    final cb = widget.onLongPress;
+    if (cb == null) return;
+    cb();
+  }
+
   KeyEventResult _onKey(FocusNode node, KeyEvent event) {
     // Deliberately NOT gated on accessibleNavigation. Fire TV reports that flag
     // true after returning from the native player even with no screen reader
     // running, and the old gate dead-keyed OK on everything (nothing was left
     // to fire the Semantics.onTap fallback). _activate dedupes if a real screen
     // reader delivers the click on both channels.
-    if (event is KeyDownEvent && okKeys.contains(event.logicalKey)) {
-      _activate();
+    if (!okKeys.contains(event.logicalKey)) return KeyEventResult.ignored;
+
+    final longPress = widget.onLongPress;
+
+    if (event is KeyDownEvent) {
+      if (longPress == null) {
+        _activate();
+        return KeyEventResult.handled;
+      }
+      // Wait for hold vs release — KeyDown used to fire tap immediately, so a
+      // held OK never had a chance to become a long-press.
+      _okHeld = true;
+      _longPressFired = false;
+      _cancelLongPressTimer();
+      _longPressTimer = Timer(kLongPressTimeout, () {
+        if (!mounted || !_okHeld) return;
+        _longPressFired = true;
+        _fireLongPress();
+      });
       return KeyEventResult.handled;
     }
+
+    if (longPress == null) return KeyEventResult.ignored;
+
+    if (event is KeyRepeatEvent) {
+      // Swallow repeats so they cannot be treated as extra taps.
+      return KeyEventResult.handled;
+    }
+
+    if (event is KeyUpEvent) {
+      _okHeld = false;
+      _cancelLongPressTimer();
+      if (!_longPressFired) _activate();
+      return KeyEventResult.handled;
+    }
+
     return KeyEventResult.ignored;
   }
 
@@ -251,6 +316,7 @@ class _TvFocusableState extends State<TvFocusable> {
         button: widget.isButton,
         focused: _focused,
         onTap: _activate,
+        onLongPress: widget.onLongPress,
         child: Focus(
           focusNode: widget.focusNode,
           autofocus: widget.autofocus,
@@ -263,6 +329,9 @@ class _TvFocusableState extends State<TvFocusable> {
                 alignment: 0.5,
                 duration: const Duration(milliseconds: 200),
               );
+            } else {
+              _okHeld = false;
+              _cancelLongPressTimer();
             }
           },
           // Touch support: some Android TVs / TV boxes have a touchscreen. A
@@ -276,6 +345,7 @@ class _TvFocusableState extends State<TvFocusable> {
             behavior: HitTestBehavior.opaque,
             excludeFromSemantics: true,
             onTap: _activate,
+            onLongPress: widget.onLongPress,
             child: box,
           ),
         ),

--- a/lib/core/tv/tv_poster_tile.dart
+++ b/lib/core/tv/tv_poster_tile.dart
@@ -15,6 +15,7 @@ class TvPosterTile extends StatelessWidget {
     this.headers,
     this.tags = const [],
     required this.onTap,
+    this.onLongPress,
     this.autofocus = false,
   });
 
@@ -23,6 +24,7 @@ class TvPosterTile extends StatelessWidget {
   final Map<String, String>? headers;
   final List<String> tags;
   final VoidCallback onTap;
+  final VoidCallback? onLongPress;
   final bool autofocus;
 
   @override
@@ -38,6 +40,7 @@ class TvPosterTile extends StatelessWidget {
             variant: TvFocusVariant.float,
             scale: 1.04,
             onTap: onTap,
+            onLongPress: onLongPress,
             semanticLabel: title,
             child: PosterCard(
               title: title,
@@ -45,7 +48,8 @@ class TvPosterTile extends StatelessWidget {
               headers: headers,
               tags: tags,
               showTitle: false,
-              // Touch gestures are disabled on TV; TvFocusable handles OK-key.
+              // Touch gestures are disabled on TV; TvFocusable handles OK-key
+              // (including held-OK long-press when [onLongPress] is set).
               onTap: null,
               onLongPress: null,
             ),

--- a/lib/core/ui/list_status_sheet.dart
+++ b/lib/core/ui/list_status_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../app_mode.dart';
 import '../di/injector.dart';
 import '../models/media_item.dart';
 import '../models/provider_info.dart';
@@ -11,6 +12,7 @@ import '../theme/app_colors.dart';
 import '../theme/app_text.dart';
 import '../tracker/tracker.dart';
 import '../tracker/tracker_hub.dart';
+import '../tv/tv_focusable.dart';
 
 /// Sentinel popped by [ListStatusSheet] for the "Remove from list" row.
 const String _kRemove = '__remove__';
@@ -44,6 +46,7 @@ Future<void> showListStatusSheet(
 
   final picked = await showModalBottomSheet<Object?>(
     context: context,
+    isScrollControlled: true,
     backgroundColor: AppColors.surface,
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
@@ -154,60 +157,101 @@ class ListStatusSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final statuses = WatchStatus.values;
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const SizedBox(height: 10),
-          Container(
-            width: 36,
-            height: 4,
-            decoration: BoxDecoration(
-              color: AppColors.hairline,
-              borderRadius: BorderRadius.circular(2),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 14, 20, 6),
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: Text('Add to your list', style: AppText.headline),
-            ),
-          ),
-          for (final s in WatchStatus.values)
-            ListTile(
-              leading: Icon(
-                _iconFor(s),
-                color: current == s ? AppColors.accent : AppColors.textSecondary,
-              ),
-              title: Text(
-                labelFor(s, reading: reading),
-                style: AppText.body.copyWith(
-                  color: current == s ? AppColors.accent : AppColors.textPrimary,
-                  fontWeight: current == s ? FontWeight.w600 : FontWeight.w400,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.85,
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 10),
+              Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: AppColors.hairline,
+                  borderRadius: BorderRadius.circular(2),
                 ),
               ),
-              trailing: current == s
-                  ? Icon(Icons.check_rounded, color: AppColors.accent)
-                  : null,
-              onTap: () => Navigator.pop(context, s),
-            ),
-          if (inList) ...[
-            const Divider(height: 1, color: AppColors.hairline),
-            ListTile(
-              leading: Icon(
-                Icons.delete_outline_rounded,
-                color: AppColors.accent,
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 14, 20, 6),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text('Add to your list', style: AppText.headline),
+                ),
               ),
-              title: Text(
-                'Remove from list',
-                style: AppText.body.copyWith(color: AppColors.accent),
-              ),
-              onTap: () => Navigator.pop(context, _kRemove),
-            ),
-          ],
-          const SizedBox(height: 8),
-        ],
+              for (var i = 0; i < statuses.length; i++)
+                _row(
+                  autofocus: i == 0,
+                  onTap: () => Navigator.pop(context, statuses[i]),
+                  child: ListTile(
+                    leading: Icon(
+                      _iconFor(statuses[i]),
+                      color: current == statuses[i]
+                          ? AppColors.accent
+                          : AppColors.textSecondary,
+                    ),
+                    title: Text(
+                      labelFor(statuses[i], reading: reading),
+                      style: AppText.body.copyWith(
+                        color: current == statuses[i]
+                            ? AppColors.accent
+                            : AppColors.textPrimary,
+                        fontWeight: current == statuses[i]
+                            ? FontWeight.w600
+                            : FontWeight.w400,
+                      ),
+                    ),
+                    trailing: current == statuses[i]
+                        ? Icon(Icons.check_rounded, color: AppColors.accent)
+                        : null,
+                    onTap: () => Navigator.pop(context, statuses[i]),
+                  ),
+                ),
+              if (inList) ...[
+                const Divider(height: 1, color: AppColors.hairline),
+                _row(
+                  onTap: () => Navigator.pop(context, _kRemove),
+                  child: ListTile(
+                    leading: Icon(
+                      Icons.delete_outline_rounded,
+                      color: AppColors.accent,
+                    ),
+                    title: Text(
+                      'Remove from list',
+                      style: AppText.body.copyWith(color: AppColors.accent),
+                    ),
+                    onTap: () => Navigator.pop(context, _kRemove),
+                  ),
+                ),
+              ],
+              const SizedBox(height: 8),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Phone keeps the ListTile as-is. TV wraps it so D-pad OK can pick a status
+  /// after a held-OK on a My List poster (ListTile alone has no TV key path).
+  Widget _row({
+    required Widget child,
+    required VoidCallback onTap,
+    bool autofocus = false,
+  }) {
+    if (!sl.isRegistered<AppMode>() || !sl<AppMode>().isTv) return child;
+    return TvFocusable(
+      scale: 1.0,
+      autofocus: autofocus,
+      onTap: onTap,
+      child: Focus(
+        canRequestFocus: false,
+        descendantsAreFocusable: false,
+        child: child,
       ),
     );
   }

--- a/lib/features/home/my_list_screen_tv.dart
+++ b/lib/features/home/my_list_screen_tv.dart
@@ -5,6 +5,7 @@ import '../../core/models/media_item.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_text.dart';
 import '../../core/tv/tv_poster_tile.dart';
+import '../../core/ui/list_status_sheet.dart';
 import '../../core/ui/states.dart';
 import '../detail/detail_screen.dart';
 import 'cubit/my_list_cubit.dart';
@@ -13,9 +14,10 @@ import 'cubit/my_list_cubit.dart';
 ///
 /// Reuses the phone's cubit/state and [PosterCard] widget unchanged. Only the
 /// interaction model changes: each card is wrapped in [TvFocusable] so the
-/// D-pad navigates the grid and OK opens the Detail screen — matching the phone
-/// tap behaviour. The rail↔content focus bridge in [RootShellTv] already
-/// handles LEFT-at-edge → rail, so no additional navigation plumbing is needed.
+/// D-pad navigates the grid, OK opens the Detail screen, and a held OK opens
+/// the same status/remove sheet as the phone long-press. The rail↔content
+/// focus bridge in [RootShellTv] already handles LEFT-at-edge → rail, so no
+/// additional navigation plumbing is needed.
 ///
 /// The phone [MyListScreen] is byte-identical except for the single
 /// `if (sl<AppMode>().isTv) return const MyListScreenTv();` branch added at
@@ -75,6 +77,14 @@ class MyListScreenTv extends StatelessWidget {
                         imageUrl: entry.item.cover,
                         headers: entry.item.coverHeaders,
                         onTap: () => _openItem(context, entry.item),
+                        onLongPress: () {
+                          final cubit = context.read<MyListCubit>();
+                          showListStatusSheet(
+                            context,
+                            item: entry.item,
+                            onChanged: cubit.reload,
+                          );
+                        },
                       );
                     },
                   );

--- a/lib/features/home/see_all_screen_tv.dart
+++ b/lib/features/home/see_all_screen_tv.dart
@@ -161,6 +161,9 @@ class _SeeAllScreenTvState extends State<SeeAllScreenTv> {
                 headers: item.coverHeaders,
                 tags: widget.tagsFor?.call(item) ?? const [],
                 onTap: () => widget.onTap(item),
+                onLongPress: widget.onLongPress == null
+                    ? null
+                    : () => widget.onLongPress!(item),
               );
             },
           ),

--- a/test/core/tv/tv_focusable_test.dart
+++ b/test/core/tv/tv_focusable_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,6 +19,60 @@ void main() {
     await tester.pumpAndSettle();
     expect(taps, 1);
   });
+
+  testWidgets(
+    'with onLongPress, a short OK press still fires onTap (not long-press)',
+    (tester) async {
+      var taps = 0;
+      var longs = 0;
+      await tester.pumpWidget(MaterialApp(
+        home: TvFocusable(
+          autofocus: true,
+          onTap: () => taps++,
+          onLongPress: () => longs++,
+          child: const SizedBox(width: 100, height: 100),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(taps, 0);
+      expect(longs, 0);
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(taps, 1);
+      expect(longs, 0);
+    },
+  );
+
+  testWidgets(
+    'with onLongPress, holding OK past the long-press timeout fires onLongPress only',
+    (tester) async {
+      var taps = 0;
+      var longs = 0;
+      await tester.pumpWidget(MaterialApp(
+        home: TvFocusable(
+          autofocus: true,
+          onTap: () => taps++,
+          onLongPress: () => longs++,
+          child: const SizedBox(width: 100, height: 100),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      expect(longs, 1);
+      expect(taps, 0);
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(longs, 1);
+      expect(taps, 0);
+    },
+  );
 
   testWidgets(
     'TvFocusable focused border is a white outline',

--- a/test/core/ui/list_status_sheet_test.dart
+++ b/test/core/ui/list_status_sheet_test.dart
@@ -9,6 +9,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:watch_app/core/app_mode.dart';
 import 'package:watch_app/core/di/injector.dart';
 import 'package:watch_app/core/models/media_item.dart';
 import 'package:watch_app/core/models/provider_info.dart';
@@ -317,6 +318,38 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(fake.lastRemoveKind, MediaKind.manga);
+    },
+  );
+
+  testWidgets(
+    'does not overflow on a 720p landscape TV with every row present',
+    (tester) async {
+      sl.registerSingleton<AppMode>(const AppMode(isTv: true));
+      await sl<MyListStore>().add(_animeItem);
+
+      tester.view.physicalSize = const Size(1280, 720);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () =>
+                    showListStatusSheet(context, item: _animeItem),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add to your list'), findsOneWidget);
+      expect(find.text('Remove from list'), findsOneWidget);
+      expect(tester.takeException(), isNull);
     },
   );
 }

--- a/test/features/home/my_list_screen_tv_test.dart
+++ b/test/features/home/my_list_screen_tv_test.dart
@@ -94,6 +94,10 @@ void main() {
 
       // The very first TvFocusable (first poster card) has autofocus=true.
       expect(focusables.first.autofocus, isTrue);
+
+      // Held OK on a card must have a long-press handler (status / remove),
+      // matching phone long-press. Without this, TvFocusable treats OK as tap.
+      expect(focusables.first.onLongPress, isNotNull);
     },
   );
 


### PR DESCRIPTION
## What changed
On TV, a held OK/Select on a My List poster never opened the status/remove options. `TvFocusable` treated remote OK as an instant tap on KeyDown, so a long-hold had no chance to register.
- Held OK (same timeout as a touch long-press) opens the same **Add to your list** sheet as phone long-press; a short OK still opens Detail.
- Buttons without a long-press handler stay immediate on KeyDown.
- The status sheet is scroll-controlled and capped so it does not overflow on landscape TV.
- Phone long-press / bottom sheet behavior is unchanged.
Closes #25
## How you tested it
- Widget tests for short vs held OK, My List wiring, and a 720p landscape TV sheet with every row present (no overflow).
- TV: held OK on a My List item opens status/remove; short OK still opens the title.
- Phone: long-press on a My List item still shows the bottom sheet (portrait and landscape).
## Checklist
- [x] `flutter analyze` is clean
- [x] `flutter test` passes (focused: `tv_focusable`, `list_status_sheet`, `my_list_screen_tv`)
- [x] Native build still compiles, if I touched `android/` or `ios/` (not touched)
- [x] I've read and agree to the [CLA](../CLA.md)
- [x] New dependency or third-party code? [`NOTICE.md`](../NOTICE.md) updated in this PR (N/A)
- [x] Used AI tooling? Disclosed per [`AI_POLICY.md`](../AI_POLICY.md)
AI assistance: used Cursor to implement the TV long-press path and the sheet overflow fix; reviewed and tested on phone (bottom sheet) and TV.

## Screenshots

### Phone — long-press still correct size:

<img width="449" height="1015" alt="CleanShot 2026-08-18 at 13 54 59" src="https://github.com/user-attachments/assets/a5534c22-a753-4729-b854-b8defc71460c" />

### TV - Status Sheet:

<img width="1682" height="947" alt="CleanShot 2026-08-18 at 13 52 26" src="https://github.com/user-attachments/assets/a7803f5d-a454-4add-b7b8-2e40558c3cc3" />