### PR TITLE
feat(tv): add Clear on recent searches in TV search

### DIFF
--- a/lib/features/home/search_screen.dart
+++ b/lib/features/home/search_screen.dart
@@ -79,7 +79,10 @@ class SearchScreen extends StatelessWidget {
       // above is still the provider for both paths — SearchScreenTv reads the
       // same SearchBloc from context, so no duplication of bloc creation.
       child: sl<AppMode>().isTv
-          ? SearchScreenTv(initialQuery: initialQuery)
+          ? SearchScreenTv(
+              initialQuery: initialQuery,
+              history: sl<SearchHistory>(),
+            )
           : _SearchView(
               initialQuery: initialQuery,
               showBack: showBack,

--- a/lib/features/home/search_screen_tv.dart
+++ b/lib/features/home/search_screen_tv.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../core/models/media_item.dart';
+import '../../core/playback/search_history.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_text.dart';
 import '../../core/tv/tv_focusable.dart';
@@ -30,8 +31,12 @@ import '../search/bloc/search_state.dart';
 /// `if (sl<AppMode>().isTv) return SearchScreenTv(...)` branch added in its
 /// [SearchScreen.build] method.
 class SearchScreenTv extends StatefulWidget {
-  const SearchScreenTv({super.key, this.initialQuery});
+  const SearchScreenTv({super.key, this.initialQuery, this.history});
   final String? initialQuery;
+
+  /// Recent search terms. Production [SearchScreen] passes the injector
+  /// singleton; tests pass a stub (or omit it) so they don't need GetIt.
+  final SearchHistory? history;
 
   @override
   State<SearchScreenTv> createState() => _SearchScreenTvState();
@@ -307,10 +312,7 @@ class _SearchScreenTvState extends State<SearchScreenTv> {
                   }
                   switch (state.status) {
                     case SearchStatus.idle:
-                      return const EmptyState(
-                        icon: Icons.search_rounded,
-                        message: 'Search for something to watch',
-                      );
+                      return _idleView();
                     case SearchStatus.loading:
                       return Padding(
                         padding: const EdgeInsets.fromLTRB(40, 8, 40, 40),
@@ -335,6 +337,104 @@ class _SearchScreenTvState extends State<SearchScreenTv> {
           ],
         ),
       ),
+    );
+  }
+
+  // ── Idle (recent searches + empty prompt) ───────────────────────────────────
+
+  /// Idle body: recent terms with a D-pad-focusable Clear, matching the phone
+  /// landing page. Falls back to the empty prompt when there's nothing stored
+  /// (tests that omit [SearchScreenTv.history] hit this path too).
+  Widget _idleView() {
+    final history = widget.history;
+    final recent = history?.recent() ?? const <String>[];
+    if (history == null || recent.isEmpty) {
+      return const EmptyState(
+        icon: Icons.search_rounded,
+        message: 'Search for something to watch',
+      );
+    }
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(48, 8, 48, 12),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text('Recent searches', style: AppText.overline),
+              ),
+              TvFocusable(
+                key: const ValueKey('tv-search-clear-history'),
+                variant: TvFocusVariant.pill,
+                scale: 1.0,
+                semanticLabel: 'Clear search history',
+                onTap: () async {
+                  await history.clear();
+                  if (mounted) setState(() {});
+                },
+                builder: (focused) {
+                  final fg = focused ? Colors.black : AppColors.accent;
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 8,
+                    ),
+                    child: Text(
+                      'Clear',
+                      style: TextStyle(
+                        color: fg,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+        for (final q in recent)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 48, vertical: 2),
+            child: TvFocusable(
+              scale: 1.0,
+              onTap: () {
+                _controller.value = TextEditingValue(
+                  text: q,
+                  selection: TextSelection.collapsed(offset: q.length),
+                );
+                context.read<SearchBloc>().add(SearchRunRequested(q));
+              },
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 14,
+                ),
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.history_rounded,
+                      size: 18,
+                      color: AppColors.textTertiary,
+                    ),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: Text(
+                        q,
+                        style: AppText.body.copyWith(
+                          color: AppColors.textPrimary,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+      ],
     );
   }
 

--- a/test/features/home/search_screen_tv_test.dart
+++ b/test/features/home/search_screen_tv_test.dart
@@ -29,6 +29,26 @@ class _StubSearchHistory extends SearchHistory {
   Future<void> clear() async {}
 }
 
+/// [SearchHistory] stub with a mutable list so Clear can be asserted.
+class _MutableSearchHistory extends SearchHistory {
+  _MutableSearchHistory(this._recent);
+  List<String> _recent;
+
+  @override
+  List<String> recent() => List.unmodifiable(_recent);
+
+  @override
+  Future<void> add(String query) async {}
+
+  @override
+  Future<void> remove(String query) async {}
+
+  @override
+  Future<void> clear() async {
+    _recent = [];
+  }
+}
+
 /// [SearchPrefs] stub: no Hive dependency, returns safe defaults.
 /// Only the getters that [SearchBloc._restoredState] calls are overridden.
 class _StubSearchPrefs extends SearchPrefs {
@@ -104,9 +124,10 @@ class _FakeSearchBloc extends SearchBloc {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-Widget _buildUnderTest(_FakeSearchBloc bloc) => BlocProvider<SearchBloc>.value(
+Widget _buildUnderTest(_FakeSearchBloc bloc, {SearchHistory? history}) =>
+    BlocProvider<SearchBloc>.value(
       value: bloc,
-      child: const MaterialApp(home: SearchScreenTv()),
+      child: MaterialApp(home: SearchScreenTv(history: history)),
     );
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -156,11 +177,15 @@ void main() {
 
       expect(find.text('Search for something to watch'), findsOneWidget);
       // The scope chips are always visible (2 TvFocusables), but no result
-      // cards exist in idle state.
+      // cards exist in idle state. Clear history is hidden until recents exist.
       expect(find.byType(TvFocusable), findsNWidgets(2));
       expect(
         find.byKey(const ValueKey('tv-search-scope-current')),
         findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('tv-search-clear-history')),
+        findsNothing,
       );
     },
   );
@@ -319,6 +344,50 @@ void main() {
         tester.binding.focusManager.primaryFocus,
         isNot(same(fieldNode)),
       );
+    },
+  );
+
+  testWidgets(
+    'SearchScreenTv idle lists recent searches and a Clear button',
+    (tester) async {
+      final bloc =
+          _FakeSearchBloc(SearchState(status: SearchStatus.idle));
+      addTearDown(bloc.close);
+      final history = _MutableSearchHistory(['Naruto', 'One Piece']);
+
+      await tester.pumpWidget(_buildUnderTest(bloc, history: history));
+      await tester.pump();
+
+      expect(find.text('Recent searches'), findsOneWidget);
+      expect(find.text('Naruto'), findsOneWidget);
+      expect(find.text('One Piece'), findsOneWidget);
+      expect(find.text('Clear'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('tv-search-clear-history')),
+        findsOneWidget,
+      );
+      expect(find.text('Search for something to watch'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'SearchScreenTv Clear wipes recents and returns to the empty idle prompt',
+    (tester) async {
+      final bloc =
+          _FakeSearchBloc(SearchState(status: SearchStatus.idle));
+      addTearDown(bloc.close);
+      final history = _MutableSearchHistory(['Naruto']);
+
+      await tester.pumpWidget(_buildUnderTest(bloc, history: history));
+      await tester.pump();
+
+      await tester.tap(find.byKey(const ValueKey('tv-search-clear-history')));
+      await tester.pump();
+
+      expect(history.recent(), isEmpty);
+      expect(find.text('Recent searches'), findsNothing);
+      expect(find.byKey(const ValueKey('tv-search-clear-history')), findsNothing);
+      expect(find.text('Search for something to watch'), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
## What changed

TV search idle now matches phone: it lists **Recent searches** and a D-pad **Clear** control that wipes local search history. Tapping a recent term fills the field and runs that search. With no recents, the empty prompt is unchanged.

Closes #27

## How you tested it

- Widget tests: idle empty prompt hides Clear; recents render with Clear; Clear empties history and returns to the empty prompt (`test/features/home/search_screen_tv_test.dart`, 9 passing).
- TV: idle search shows recents + Clear; OK on Clear wipes them.
- Tested on Emulator, Google Chromecast, and Onn 4K box

## Checklist

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (focused: `search_screen_tv_test`)
- [x] Native build still compiles, if I touched `android/` or `ios/` (not touched)
- [x] I've read and agree to the [CLA](../CLA.md)
- [x] New dependency or third-party code? [`NOTICE.md`](../NOTICE.md) updated in this PR (N/A)
- [x] Used AI tooling? Disclosed per [`AI_POLICY.md`](../AI_POLICY.md)

AI assistance: used Cursor to implement the TV idle recents/Clear UI and tests; reviewed and exercised on TV search.

## Screenshots

<img width="3230" height="1812" alt="CleanShot 2026-08-18 at 22 06 33@2x" src="https://github.com/user-attachments/assets/fb7b8d59-dbf6-4904-a5b6-8795baa1aa5d" />

<img width="3232" height="1812" alt="CleanShot 2026-08-18 at 22 06 45@2x" src="https://github.com/user-attachments/assets/98069437-d041-4c6a-a4bd-ed59c09eccb7" />
