### PR TITLE
Enhance Discord Rich Presence

### DIFF
--- a/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
@@ -126,6 +126,8 @@ class TvPlayerActivity : Activity() {
     private data class Skip(val start: Long, val end: Long, val type: String)
     private var skipIntervals: List<Skip> = emptyList()
     private var skipsFetchedFor = -1 // episode index skips were fetched for
+    private var timingReportedFor = -1 // episode index Dart was told duration for
+    private var userPaused = false // true only after an explicit pause press
     private var activeSkipEnd = -1L  // end of the interval currently offered
 
     private lateinit var root: View
@@ -190,7 +192,10 @@ class TvPlayerActivity : Activity() {
     private val commitSeek = Runnable {
         val t = seekTarget
         seekTarget = -1L
-        if (t >= 0) player?.seekTo(t)
+        if (t >= 0) {
+            player?.seekTo(t)
+            reportTiming(positionMs = t)
+        }
     }
     private val ticker = object : Runnable {
         override fun run() {
@@ -277,6 +282,7 @@ class TvPlayerActivity : Activity() {
                 }
                 // Duration is known once ready → fetch AniSkip for this episode.
                 if (state == Player.STATE_READY && skipsFetchedFor != currentIndex) fetchSkips()
+                if (state == Player.STATE_READY) reportTimingIfNeeded()
                 // Autoplay the next episode when this one finishes.
                 if (state == Player.STATE_ENDED && !switching && currentIndex < episodeCount - 1) {
                     loadEpisode(currentIndex + 1)
@@ -313,6 +319,7 @@ class TvPlayerActivity : Activity() {
         drmKey: String? = null,
     ) {
         val p = player ?: return
+        userPaused = false
         currentUrl = url
         currentHeaders = headers
         currentMime = mime
@@ -400,6 +407,7 @@ class TvPlayerActivity : Activity() {
         currentIndex = index
         skipIntervals = emptyList()
         skipsFetchedFor = -1
+        timingReportedFor = -1
         autoSkipped.clear() // new episode → its OP/ED may auto-skip again
         hideSkip()
         loadStream(
@@ -437,6 +445,30 @@ class TvPlayerActivity : Activity() {
         btnNext.isFocusable = hasNext
         btnNext.alpha = if (hasNext) 1f else 0.35f
     }
+
+    /** Push position+duration to Dart (Discord bar + resume). */
+    private fun reportTiming(
+        positionMs: Long? = null,
+        playing: Boolean? = null,
+        onlyOncePerEpisode: Boolean = false,
+    ) {
+        val p = player ?: return
+        if (p.duration <= 0) return
+        if (onlyOncePerEpisode && timingReportedFor == currentIndex) return
+        timingReportedFor = currentIndex
+        MainActivity.tvBridge?.invokeMethod(
+            "saveProgress",
+            mapOf(
+                "index" to currentIndex,
+                "positionMs" to (positionMs ?: p.currentPosition).coerceAtLeast(0L),
+                "durationMs" to p.duration,
+                "playing" to (playing ?: !userPaused),
+            ),
+        )
+    }
+
+    /** First time this episode is ready — Discord needs an end timestamp. */
+    private fun reportTimingIfNeeded() = reportTiming(onlyOncePerEpisode = true)
 
     private fun toastFail() = android.widget.Toast.makeText(
         this, "Couldn't load that episode", android.widget.Toast.LENGTH_SHORT,
@@ -501,6 +533,7 @@ class TvPlayerActivity : Activity() {
         autoSkipped.add(iv.start)
         hideSkip()
         p.seekTo(iv.end)
+        reportTiming(positionMs = iv.end)
         return true
     }
 
@@ -1105,7 +1138,12 @@ class TvPlayerActivity : Activity() {
         skipButton.onFocusChangeListener =
             View.OnFocusChangeListener { v, has -> applyPillFocus(v as TextView, has) }
         skipButton.setOnClickListener {
-            if (activeSkipEnd > 0) { player?.seekTo(activeSkipEnd); seekTarget = -1L }
+            if (activeSkipEnd > 0) {
+                val end = activeSkipEnd
+                player?.seekTo(end)
+                seekTarget = -1L
+                reportTiming(positionMs = end)
+            }
             hideSkip()
         }
     }
@@ -1197,7 +1235,15 @@ class TvPlayerActivity : Activity() {
     // ── Playback actions ─────────────────────────────────────────────────────
     private fun togglePlayPause() {
         val p = player ?: return
-        if (p.isPlaying) p.pause() else p.play()
+        if (p.playWhenReady) {
+            p.pause()
+            userPaused = true
+            reportTiming(playing = false)
+        } else {
+            p.play()
+            userPaused = false
+            reportTiming(playing = true)
+        }
         bumpControls()
     }
 

--- a/lib/core/discord/discord_config.dart
+++ b/lib/core/discord/discord_config.dart
@@ -10,8 +10,15 @@ class DiscordConfig {
   /// Zangetsu's Discord Application ID (Developer Portal → General Information).
   static const String applicationId = '1518610045422665748';
 
-  /// Rich-Presence art-asset key for the small "app" icon (uploaded to the app).
+  /// Rich-Presence art-asset key for a named portal upload (optional). We
+  /// prefer [appLogoUrl] via the external-assets API so browsing doesn't
+  /// fall back to Discord's question-mark placeholder when `logo` isn't
+  /// uploaded in the Developer Portal.
   static const String appLogoAsset = 'logo';
+
+  /// Public square app icon Discord can proxy (same file as the launcher).
+  static const String appLogoUrl =
+      'https://cdn.jsdelivr.net/gh/Spyou/Zangetsu@main/assets/icon/app_icon.png';
 
   static const String appName = 'Zangetsu';
 

--- a/lib/core/discord/discord_gateway.dart
+++ b/lib/core/discord/discord_gateway.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'discord_config.dart';
@@ -33,15 +34,20 @@ class DiscordGateway {
   void _open() {
     _cleanupSocket();
     _ready = false;
+    debugPrint('[discord] gateway opening ${DiscordConfig.gatewayUrl}');
     try {
       _ch = WebSocketChannel.connect(Uri.parse(DiscordConfig.gatewayUrl));
       _sub = _ch!.stream.listen(
         _onMessage,
         onDone: _onDone,
-        onError: (_) => _onDone(),
+        onError: (e, st) {
+          debugPrint('[discord] gateway socket error: $e');
+          _onDone();
+        },
         cancelOnError: true,
       );
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[discord] gateway connect failed: $e');
       _scheduleReconnect();
     }
   }
@@ -50,7 +56,8 @@ class DiscordGateway {
     Map<String, dynamic> msg;
     try {
       msg = jsonDecode(raw as String) as Map<String, dynamic>;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[discord] gateway bad json: $e');
       return;
     }
     if (msg['s'] != null) _seq = (msg['s'] as num).toInt();
@@ -58,6 +65,7 @@ class DiscordGateway {
       case 10: // HELLO
         final interval =
             ((msg['d'] as Map)['heartbeat_interval'] as num).toInt();
+        debugPrint('[discord] gateway HELLO heartbeat=${interval}ms — identifying');
         _startHeartbeat(interval);
         _identify();
       case 11: // heartbeat ACK
@@ -65,17 +73,25 @@ class DiscordGateway {
       case 1: // server requested a heartbeat
         _sendHeartbeat();
       case 7: // must reconnect
+        debugPrint('[discord] gateway requested reconnect (op 7)');
+        _reconnect();
       case 9: // invalid session
+        debugPrint('[discord] gateway invalid session (op 9) — token/identify rejected');
         _reconnect();
       case 0: // dispatch
-        if (msg['t'] == 'READY') {
+        final t = msg['t'] as String?;
+        if (t == 'READY') {
           _ready = true;
+          final user = (msg['d'] as Map?)?['user'] as Map?;
+          final name = user?['username'] ?? user?['global_name'] ?? '?';
+          debugPrint('[discord] gateway READY as $name — pushing presence');
           _sendPresence(_pending);
         }
     }
   }
 
   void _identify() {
+    debugPrint('[discord] gateway IDENTIFY');
     _send({
       'op': 2,
       'd': {
@@ -100,18 +116,34 @@ class DiscordGateway {
   /// Set (or clear, with null) the presence. Buffered until READY.
   void setPresence(DiscordActivity? activity) {
     _pending = activity;
-    if (_ready) _sendPresence(activity);
+    if (_ready) {
+      _sendPresence(activity);
+    } else {
+      debugPrint(
+        '[discord] presence queued until READY: ${activity == null ? "clear" : "type=${activity.type} ${activity.name}"}',
+      );
+    }
+  }
+
+  /// Push an empty activity list, wait for the frame to flush, then drop the
+  /// socket. Closing without this leaves the last Rich Presence on the profile.
+  Future<void> clearThenClose() async {
+    if (_closed) return;
+    setPresence(null);
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    await close();
   }
 
   void _sendPresence(DiscordActivity? a) {
+    debugPrint(
+      a == null
+          ? '[discord] sending presence clear'
+          : '[discord] sending presence type=${a.type} name="${a.name}" '
+              'details=${a.details} start=${a.startMs} end=${a.endMs}',
+    );
     _send({
       'op': 3,
-      'd': {
-        'since': null,
-        'activities': a == null ? <dynamic>[] : [a.toJson(DiscordConfig.applicationId)],
-        'status': 'online',
-        'afk': false,
-      },
+      'd': discordPresenceUpdate(a, DiscordConfig.applicationId),
     });
   }
 
@@ -120,7 +152,8 @@ class DiscordGateway {
     _acked = true;
     _heartbeat = Timer.periodic(Duration(milliseconds: intervalMs), (_) {
       if (!_acked) {
-        _reconnect(); // zombie connection — no ACK since last beat
+        debugPrint('[discord] gateway heartbeat missed — reconnecting');
+        _reconnect();
         return;
       }
       _sendHeartbeat();
@@ -135,16 +168,20 @@ class DiscordGateway {
   void _send(Map<String, dynamic> data) {
     try {
       _ch?.sink.add(jsonEncode(data));
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('[discord] gateway send failed: $e');
+    }
   }
 
   void _onDone() {
+    debugPrint('[discord] gateway socket closed ready=$_ready closed=$_closed');
     if (!_closed) _scheduleReconnect();
   }
 
   void _scheduleReconnect() {
     _cleanupSocket();
     if (_closed) return;
+    debugPrint('[discord] gateway reconnect in 5s');
     Future<void>.delayed(const Duration(seconds: 5), () {
       if (!_closed) _open();
     });

--- a/lib/core/discord/discord_presence.dart
+++ b/lib/core/discord/discord_presence.dart
@@ -1,3 +1,15 @@
+import '../models/episode.dart';
+import '../models/episode_title.dart';
+
+/// Presence "details" line: episode number plus a real title when we have one.
+/// Discord caps [details] at 128 characters.
+String? discordEpisodeLabel(Episode ep, {int? fallbackNumber}) {
+  final out = episodePresenceDetails(ep, fallbackNumber: fallbackNumber);
+  if (out == null) return null;
+  if (out.length <= 128) return out;
+  return '${out.substring(0, 127)}…';
+}
+
 /// Unix-ms timestamps Discord uses to draw a Rich Presence progress bar.
 ///
 /// Both [startMs] and [endMs] must be set for a bar; start-only is elapsed

--- a/lib/core/discord/discord_presence.dart
+++ b/lib/core/discord/discord_presence.dart
@@ -1,3 +1,36 @@
+/// Unix-ms timestamps Discord uses to draw a Rich Presence progress bar.
+///
+/// Both [startMs] and [endMs] must be set for a bar; start-only is elapsed
+/// time; omitting both (paused / unknown) shows no timer so the bar cannot
+/// keep marching on wall-clock time after a pause.
+({int? startMs, int? endMs}) discordPlaybackTimestamps({
+  required Duration position,
+  required Duration duration,
+  required bool playing,
+  DateTime? now,
+}) {
+  if (!playing) return (startMs: null, endMs: null);
+  final nowMs = (now ?? DateTime.now()).millisecondsSinceEpoch;
+  final posMs = position.inMilliseconds < 0 ? 0 : position.inMilliseconds;
+  final startMs = nowMs - posMs;
+  if (duration <= Duration.zero) return (startMs: startMs, endMs: null);
+  return (startMs: startMs, endMs: startMs + duration.inMilliseconds);
+}
+
+/// Gateway `op: 3` presence payload. A null [activity] is an explicit clear
+/// (`activities: []`) — dropping the socket without this leaves the last
+/// Rich Presence stuck on the profile.
+Map<String, dynamic> discordPresenceUpdate(DiscordActivity? activity, String appId) {
+  return {
+    'since': null,
+    'activities': activity == null
+        ? <dynamic>[]
+        : [activity.toJson(appId)],
+    'status': 'online',
+    'afk': false,
+  };
+}
+
 /// A Discord activity (Rich Presence). [type]: 0 Playing · 2 Listening ·
 /// 3 Watching. For Watching, [name] is what renders after "Watching ".
 class DiscordActivity {

--- a/lib/core/discord/discord_rpc.dart
+++ b/lib/core/discord/discord_rpc.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:watch_app/core/hive/safe_box.dart';
 import 'package:hive/hive.dart';
 
@@ -9,8 +12,9 @@ import 'discord_presence.dart';
 import 'discord_token_store.dart';
 
 /// Orchestrates Discord Rich Presence: holds the Gateway connection, the opt-in
-/// toggle, and builds the "watching" / "browsing" presence. Connects only while
-/// enabled + logged in + the app is foreground; clears + disconnects otherwise.
+/// toggle, and builds the "watching" / "browsing" presence. Stays connected
+/// through Android `paused` (the video player routinely fires that). Clears on
+/// player exit, disable, incognito, or process detach.
 class DiscordRpc {
   DiscordRpc(this._dio);
   final Dio _dio;
@@ -29,16 +33,31 @@ class DiscordRpc {
   bool _foreground = true;
   DiscordActivity? _current;
   final Map<String, String> _assetCache = {}; // posterUrl -> "mp:..." key
+  Timer? _clearTimer;
+  Timer? _presenceSendTimer;
+
+  /// Android pauses (and sometimes disposes) the player when the native
+  /// surface attaches. Immediate clear would wipe Watching; a short delay
+  /// lets the next [setWatching] cancel it.
+  static const Duration playerExitClearDelay = Duration(seconds: 2);
 
   bool get enabled => _enabled;
   bool get loggedIn => _token != null && _token!.isNotEmpty;
 
-  bool get _canRun =>
-      _enabled &&
-      loggedIn &&
-      DiscordConfig.configured &&
-      _foreground &&
-      !IncognitoMode.on;
+  /// Opt-in + credentials. Sending is not gated on Android `paused` — the
+  /// player leaves Flutter paused for the whole episode.
+  bool get _allowed =>
+      _enabled && loggedIn && DiscordConfig.configured && !IncognitoMode.on;
+
+  bool get _canRun => _allowed;
+
+  String get _skipReason {
+    if (!DiscordConfig.configured) return 'app id not configured';
+    if (!loggedIn) return 'not logged in';
+    if (!_enabled) return 'rich presence toggle off';
+    if (IncognitoMode.on) return 'incognito';
+    return 'ok';
+  }
 
   /// Load persisted state + connect if everything's ready. Call at startup.
   Future<void> start() async {
@@ -46,24 +65,32 @@ class DiscordRpc {
     _token = await DiscordTokenStore.read();
     // Incognito pauses presence: flipping it on drops the connection, off resumes.
     IncognitoMode.notifier.addListener(_onIncognitoChanged);
+    debugPrint(
+      '[discord] start enabled=$_enabled loggedIn=$loggedIn '
+      'configured=${DiscordConfig.configured} incognito=${IncognitoMode.on} '
+      'foreground=$_foreground → $_skipReason',
+    );
     if (_canRun) _connect();
   }
 
   void _onIncognitoChanged() {
+    debugPrint('[discord] incognito=${IncognitoMode.on}');
     if (_canRun) {
       _connect();
     } else {
-      _disconnect();
+      unawaited(_disconnect());
     }
   }
 
   Future<void> setEnabled(bool value) async {
     _enabled = value;
     await _box.put('enabled', value);
+    debugPrint('[discord] setEnabled $value');
     if (_canRun) {
       _connect();
     } else {
-      _disconnect();
+      if (!value) _current = null;
+      unawaited(_disconnect());
     }
   }
 
@@ -72,9 +99,12 @@ class DiscordRpc {
     _token = token;
     if (!loggedIn) {
       await DiscordTokenStore.clear();
-      _disconnect();
+      _current = null;
+      debugPrint('[discord] token cleared');
+      unawaited(_disconnect());
     } else {
       await DiscordTokenStore.write(token!);
+      debugPrint('[discord] discord login stored (${token.length} chars)');
       if (_canRun) _connect();
     }
   }
@@ -82,12 +112,21 @@ class DiscordRpc {
   // ── Lifecycle ─────────────────────────────────────────────────────────────
   void onForeground() {
     _foreground = true;
+    debugPrint('[discord] foreground');
     if (_canRun) _connect();
   }
 
-  void onBackground() {
+  /// Flutter `paused` — keep the gateway. Native video surfaces trigger this
+  /// for the entire playback session; clearing here made Watching vanish.
+  void onPaused() {
+    debugPrint('[discord] lifecycle paused — keeping gateway + presence');
+  }
+
+  /// Process is going away — flush an empty activity so the profile drops.
+  void onDetached() {
     _foreground = false;
-    _disconnect();
+    debugPrint('[discord] detached — clearing presence + disconnect');
+    unawaited(_disconnect());
   }
 
   // ── Presence ──────────────────────────────────────────────────────────────
@@ -95,41 +134,111 @@ class DiscordRpc {
     required String title,
     String? episodeLabel,
     String? posterUrl,
-    int? startMs,
-    int? endMs,
+    Duration position = Duration.zero,
+    Duration duration = Duration.zero,
+    bool playing = true,
   }) async {
-    if (!_canRun) return;
+    if (!_allowed) {
+      debugPrint('[discord] setWatching skipped ($_skipReason) title=$title');
+      return;
+    }
+    _cancelScheduledClear();
+    final ts = discordPlaybackTimestamps(
+      position: position,
+      duration: duration,
+      playing: playing,
+    );
     final large = posterUrl != null ? await _externalAsset(posterUrl) : null;
+    final logo = await _appLogoKey();
     _current = DiscordActivity(
       name: title,
       type: 3, // Watching
       details: episodeLabel,
       state: 'on ${DiscordConfig.appName}',
-      largeImage: large ?? DiscordConfig.appLogoAsset,
+      largeImage: large ?? logo,
       largeText: title,
-      smallImage: large != null ? DiscordConfig.appLogoAsset : null,
+      smallImage: large != null ? logo : null,
       smallText: 'Watching on ${DiscordConfig.appName}',
-      startMs: startMs,
-      endMs: endMs,
+      startMs: ts.startMs,
+      endMs: ts.endMs,
     );
-    _gateway?.setPresence(_current);
+    debugPrint(
+      '[discord] setWatching "$title" ${episodeLabel ?? ''} '
+      'playing=$playing pos=${position.inSeconds}s dur=${duration.inSeconds}s '
+      'bar=${ts.startMs != null && ts.endMs != null}'
+      '${duration <= Duration.zero ? " (end=null until duration known)" : ""} '
+      'gateway=${_gateway != null} readySend=$_canRun',
+    );
+    if (_canRun) {
+      _queuePresenceSend();
+    } else {
+      debugPrint('[discord] setWatching held, not sent ($_skipReason)');
+    }
   }
 
   Future<void> setBrowsing({String? title, String? posterUrl}) async {
-    if (!_canRun) return;
+    if (!_allowed) {
+      debugPrint('[discord] setBrowsing skipped ($_skipReason)');
+      return;
+    }
+    _cancelScheduledClear();
     final large = posterUrl != null ? await _externalAsset(posterUrl) : null;
+    final logo = await _appLogoKey();
     _current = DiscordActivity(
       name: DiscordConfig.appName,
       type: 0, // Playing → "Playing Zangetsu"
       details: title != null ? 'Looking at $title' : 'Browsing',
-      largeImage: large ?? DiscordConfig.appLogoAsset,
+      largeImage: large ?? logo,
       largeText: title ?? DiscordConfig.appName,
-      smallImage: large != null ? DiscordConfig.appLogoAsset : null,
+      smallImage: large != null ? logo : null,
     );
-    _gateway?.setPresence(_current);
+    debugPrint(
+      '[discord] setBrowsing ${title ?? "(app)"} image=${_current!.largeImage} '
+      'gateway=${_gateway != null} send=$_canRun',
+    );
+    if (_canRun) {
+      _queuePresenceSend();
+    } else {
+      debugPrint('[discord] setBrowsing held, not sent ($_skipReason)');
+    }
   }
 
-  void clear() {
+  /// Discord drops status updates that arrive too close together. A Watching
+  /// line with no duration (end=null) followed ~1s later by the real bar would
+  /// leave the profile stuck without a progress bar.
+  void _queuePresenceSend() {
+    _presenceSendTimer?.cancel();
+    _presenceSendTimer = Timer(const Duration(milliseconds: 400), () {
+      if (_canRun) _gateway?.setPresence(_current);
+    });
+  }
+
+  /// Drop the current activity. [delay] is for player teardown: Android
+  /// disposes the player on `paused`, then immediately rebuilds it — a new
+  /// [setWatching] cancels the timer so Watching survives. A real exit
+  /// (no follow-up presence) still clears after the delay.
+  void clear({Duration delay = Duration.zero}) {
+    _clearTimer?.cancel();
+    if (delay <= Duration.zero) {
+      _applyClear();
+      return;
+    }
+    debugPrint('[discord] clear scheduled in ${delay.inMilliseconds}ms');
+    _clearTimer = Timer(delay, _applyClear);
+  }
+
+  void _cancelScheduledClear() {
+    if (_clearTimer == null) return;
+    debugPrint('[discord] clear cancelled (new presence)');
+    _clearTimer!.cancel();
+    _clearTimer = null;
+  }
+
+  void _applyClear() {
+    _clearTimer = null;
+    _presenceSendTimer?.cancel();
+    _presenceSendTimer = null;
+    debugPrint('[discord] clear presence gateway=${_gateway != null}');
     _current = null;
     _gateway?.setPresence(null);
   }
@@ -137,16 +246,34 @@ class DiscordRpc {
   // ── Internals ───────────────────────────────────────────────────────────
   void _connect() {
     if (_gateway != null) {
-      if (_current != null) _gateway!.setPresence(_current);
+      debugPrint('[discord] already connected — re-push current=${_current?.name}');
+      if (_current != null) {
+        _presenceSendTimer?.cancel();
+        _gateway!.setPresence(_current);
+      }
       return;
     }
+    debugPrint('[discord] connecting gateway');
     _gateway = DiscordGateway(_token!)..connect();
     if (_current != null) _gateway!.setPresence(_current);
   }
 
-  void _disconnect() {
-    _gateway?.close();
+  Future<void> _disconnect() async {
+    final g = _gateway;
     _gateway = null;
+    if (g == null) return;
+    _cancelScheduledClear();
+    _presenceSendTimer?.cancel();
+    _presenceSendTimer = null;
+    debugPrint('[discord] disconnect (flush clear first)');
+    await g.clearThenClose();
+  }
+
+  /// App logo as a Discord-displayable image key (proxied URL, not the
+  /// named `logo` portal asset — that one isn't uploaded, so Discord shows ?).
+  Future<String> _appLogoKey() async {
+    final key = await _externalAsset(DiscordConfig.appLogoUrl);
+    return key ?? DiscordConfig.appLogoUrl;
   }
 
   /// Convert a poster URL into a Discord-displayable `mp:external/...` key via
@@ -168,7 +295,8 @@ class DiscordRpc {
       final key = 'mp:$path';
       _assetCache[url] = key;
       return key;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[discord] external asset failed: $e');
       return null; // fall back to the app logo
     }
   }

--- a/lib/core/models/episode_title.dart
+++ b/lib/core/models/episode_title.dart
@@ -1,0 +1,52 @@
+import 'episode.dart';
+
+/// Strip a leading `S1 E3 -` prefix so multi-season source titles show a
+/// clean name. No-op when the title has no such prefix.
+String cleanTitle(String title) {
+  return title.replaceFirst(RegExp(r'^S\d+\s+E\d+\s*[-–—]?\s*'), '').trim();
+}
+
+/// Drop a leading generic "Episode 12" / "Ep. 12" / "E12" / "12." marker.
+/// Empty result means the source title was only that marker.
+String stripGenericEpisodePrefix(String title, int n) {
+  final t = title.trim();
+  final word = RegExp(
+    '^(?:episode|ep\\.?|e)\\s*0*$n(?![0-9])\\s*[:\\-–—.)\\]]*\\s*',
+    caseSensitive: false,
+  );
+  final bare = RegExp('^0*$n(?![0-9])\\s*[:\\-–—.)\\]]+\\s*');
+  final m = word.firstMatch(t) ?? bare.firstMatch(t);
+  if (m == null) return t;
+  return t.substring(m.end).trim();
+}
+
+int? episodeNumberInt(Episode ep) {
+  final n = ep.number;
+  if (n == null || n != n.roundToDouble()) return null;
+  return n.toInt();
+}
+
+/// Visible episode name: source title when it is real, else AniZip/TMDB
+/// [Episode.metaTitle]. Generic "Episode N" source titles do not count.
+String? episodeDisplayTitle(Episode ep, {String? sourceTitle, int? number}) {
+  final n = number ?? episodeNumberInt(ep);
+  var src = (sourceTitle ?? ep.title).trim();
+  src = cleanTitle(src);
+  if (n != null) src = stripGenericEpisodePrefix(src, n);
+  if (src.isNotEmpty) return src;
+  var meta = ep.metaTitle?.trim() ?? '';
+  if (meta.isEmpty) return null;
+  meta = cleanTitle(meta);
+  if (n != null) meta = stripGenericEpisodePrefix(meta, n);
+  return meta.isEmpty ? null : meta;
+}
+
+/// Player / Discord details line: `Episode 47 · The Title`, or `Episode 47`
+/// when no real name is known.
+String? episodePresenceDetails(Episode ep, {int? fallbackNumber}) {
+  final n = episodeNumberInt(ep) ?? fallbackNumber;
+  final title = episodeDisplayTitle(ep, number: n);
+  if (n == null) return title;
+  if (title == null) return 'Episode $n';
+  return 'Episode $n · $title';
+}

--- a/lib/features/detail/cubit/detail_cubit.dart
+++ b/lib/features/detail/cubit/detail_cubit.dart
@@ -11,6 +11,8 @@ import '../../../core/models/provider_info.dart';
 import '../../../core/playback/title_prefs.dart';
 import '../../../core/repository/source_repository.dart';
 
+export '../../../core/models/episode_title.dart' show cleanTitle;
+
 /// Lifecycle of the detail load. Mirrors Sozo Read's `DetailStatus`
 /// (we drop `initial` — the cubit starts in `loading` since `load()`
 /// fires immediately on construction).
@@ -357,12 +359,6 @@ Set<int> seasonsOf(List<Episode> eps) {
     if (s != null) result.add(s);
   }
   return result;
-}
-
-/// Strip a leading season+episode prefix from a title so the episode
-/// row shows a clean title without redundant numbering.
-String cleanTitle(String title) {
-  return title.replaceFirst(RegExp(r'^S\d+\s+E\d+\s*[-–—]?\s*'), '').trim();
 }
 
 /// Whether to show the Sub/Dub toggle:

--- a/lib/features/detail/detail_episodes.dart
+++ b/lib/features/detail/detail_episodes.dart
@@ -1024,14 +1024,7 @@ class _EpisodeRow extends StatelessWidget {
     // "Episode N" (or nothing); keep the source's own title when it has a real
     // one.
     final srcTitle = displayTitle.trim();
-    final isGenericSrc =
-        srcTitle.isEmpty ||
-        srcTitle.toLowerCase() == 'episode $epNum' ||
-        srcTitle.toLowerCase() == 'episode ${epNum.toString().padLeft(2, '0')}';
-    final metaTitle = ep.metaTitle?.trim();
-    final titleText = (isGenericSrc && metaTitle != null && metaTitle.isNotEmpty)
-        ? metaTitle
-        : srcTitle;
+    final titleText = episodeDisplayTitle(ep, sourceTitle: srcTitle, number: epNum) ?? '';
     final heading = titleText.isNotEmpty
         ? '$epNum. $titleText'
         : 'Episode $epNum';

--- a/lib/features/detail/detail_screen.dart
+++ b/lib/features/detail/detail_screen.dart
@@ -23,6 +23,7 @@ import '../../core/share/share_link.dart';
 import '../../core/download/download_manager.dart';
 import '../../core/download/download_record.dart';
 import '../../core/models/episode.dart';
+import '../../core/models/episode_title.dart';
 import '../../core/models/media_detail.dart';
 import 'chapter_meta.dart';
 import 'episode_filter.dart';

--- a/lib/features/detail/detail_screen_tv.dart
+++ b/lib/features/detail/detail_screen_tv.dart
@@ -225,6 +225,8 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
         availableCategories: availableCategories,
         malId: detail.malId ?? widget.item.malId,
         scrobbleTitle: detail.type == ProviderType.anime ? detail.title : null,
+        tmdbId: detail.tmdbId ?? widget.item.tmdbId,
+        tmdbIsTv: detail.tmdbIsTv,
       );
       if (!started && mounted) await showTvPlaybackLoadError(context);
       return;

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -413,6 +413,8 @@ class _HomeViewState extends State<_HomeView>
           category: category,
           malId: item.malId,
           scrobbleTitle: item.type == ProviderType.anime ? item.title : null,
+          tmdbId: item.tmdbId,
+          tmdbIsTv: item.tmdbIsTv,
         ),
       ),
     );

--- a/lib/features/home/home_screen_tv.dart
+++ b/lib/features/home/home_screen_tv.dart
@@ -116,6 +116,8 @@ class _HomeScreenTvState extends State<HomeScreenTv> {
         ],
         malId: item.malId,
         scrobbleTitle: item.type == ProviderType.anime ? item.title : null,
+        tmdbId: item.tmdbId,
+        tmdbIsTv: item.tmdbIsTv,
       );
       if (mounted) setState(() {});
       return;
@@ -140,6 +142,8 @@ class _HomeScreenTvState extends State<HomeScreenTv> {
           ],
           malId: item.malId,
           scrobbleTitle: item.type == ProviderType.anime ? item.title : null,
+          tmdbId: item.tmdbId,
+          tmdbIsTv: item.tmdbIsTv,
         ),
       ),
     );
@@ -181,6 +185,7 @@ class _HomeScreenTvState extends State<HomeScreenTv> {
         coverHeaders: e.coverHeaders,
         category: e.category,
         malId: e.malId,
+        scrobbleTitle: e.malId != null ? e.showTitle : null,
       );
       if (mounted) setState(() {});
       return;

--- a/lib/features/player/player_controller.dart
+++ b/lib/features/player/player_controller.dart
@@ -14,9 +14,12 @@ import 'package:path_provider/path_provider.dart';
 
 import '../../core/app_mode.dart';
 import '../../core/di/injector.dart';
+import '../../core/discord/discord_presence.dart';
 import '../../core/discord/discord_rpc.dart';
+import '../../core/metadata/episode_metadata_service.dart';
 import '../../core/tracker/tracker_hub.dart';
 import '../../core/models/episode.dart';
+import '../../core/models/provider_info.dart';
 import '../../core/models/video_source.dart';
 import '../../core/playback/hls.dart';
 import '../../core/playback/playback_prefs.dart';
@@ -332,6 +335,7 @@ class PlayerCubit extends Cubit<PlayerState> {
   final List<StreamSubscription> _subs = [];
   Duration _lastPos = Duration.zero;
   Duration _lastDur = Duration.zero;
+  bool _playing = true;
   // The resume position we still need to reach. Set when a resume mark is
   // applied on open and cleared once playback actually reaches it. While set, a
   // re-open (e.g. the default-quality switch that fires right after resume, when
@@ -382,6 +386,8 @@ class PlayerCubit extends Cubit<PlayerState> {
   bool _markedWatching = false;
   bool _defaultRateApplied = false; // default speed applied once per session
   bool _libassNoticeShown = false; // libass "disable if no subs" hint shown once
+  Timer? _discordPauseTimer;
+  bool _discordPaused = false;
 
   Episode get currentEpisode => episodes[state.currentIndex];
 
@@ -780,6 +786,7 @@ class PlayerCubit extends Cubit<PlayerState> {
     // (HLS fake-extension relaxation, reconnect, …) are in effect for the file.
     unawaited(_mpvConfigured);
     _ensureFiller(); // background filler lookup for auto-skip (anime only)
+    unawaited(_enrichEpisodeTitles());
     emit(state.copyWith(tracks: player.state.tracks));
     _subs.add(
       player.stream.tracks.listen((t) {
@@ -800,7 +807,28 @@ class PlayerCubit extends Cubit<PlayerState> {
       }),
     );
     _subs.add(
+      player.stream.playing.listen((v) {
+        _playing = v;
+        if (v) {
+          _discordPaused = false;
+          _discordPauseTimer?.cancel();
+          _pushDiscordWatching();
+          return;
+        }
+        // Seek/buffer briefly reports not-playing. Only freeze Discord after
+        // a real pause holds.
+        _discordPauseTimer?.cancel();
+        _discordPauseTimer = Timer(const Duration(milliseconds: 600), () {
+          if (!_playing) {
+            _discordPaused = true;
+            _pushDiscordWatching();
+          }
+        });
+      }),
+    );
+    _subs.add(
       player.stream.position.listen((p) {
+        final jumped = (p - _lastPos).abs() > const Duration(seconds: 3);
         _lastPos = p;
         // Keep the resume target as a FLOOR for re-opens until we're safely past
         // it (NOT the instant it's touched — a re-open firing right then would
@@ -845,6 +873,8 @@ class PlayerCubit extends Cubit<PlayerState> {
         // write every ~5s. NOT gated on duration — downloaded HLS (concatenated
         // TS) often reports no duration, and we still want resume to work.
         final now = DateTime.now().millisecondsSinceEpoch;
+        if (jumped) _pushDiscordWatching();
+
         if (now - _lastHistoryMs >= 5000) {
           _lastHistoryMs = now;
           _persist();
@@ -867,6 +897,7 @@ class PlayerCubit extends Cubit<PlayerState> {
     _subs.add(
       player.stream.duration.listen((d) {
         _lastDur = d;
+        if (d > Duration.zero) _pushDiscordWatching();
         // The duration arriving is mpv's "ready" signal (its STATE_READY): only
         // now is the stream reliably seekable. A remote MP4 reports duration
         // only after its moov atom loads, and any seek issued before that is
@@ -1987,17 +2018,7 @@ class PlayerCubit extends Cubit<PlayerState> {
     );
     if (g != _gen) return; // superseded mid-open
     // Discord Rich Presence: announce the episode now playing.
-    final discordTitle = showTitle ?? scrobbleTitle;
-    if (discordTitle != null &&
-        discordTitle.isNotEmpty &&
-        sl.isRegistered<DiscordRpc>()) {
-      sl<DiscordRpc>().setWatching(
-        title: discordTitle,
-        episodeLabel: 'Episode ${currentEpisode.number}',
-        posterUrl: cover,
-        startMs: DateTime.now().millisecondsSinceEpoch,
-      );
-    }
+    _pushDiscordWatching();
     // Some streams ignore Media.start (the seek-on-open doesn't take), so the
     // user lands back at 0. Verify a moment later and re-seek if needed.
     if (start > Duration.zero) {
@@ -2600,6 +2621,49 @@ class PlayerCubit extends Cubit<PlayerState> {
     );
   }
 
+  /// Push "Watching {title}" with timestamps Discord interpolates into a
+  /// progress bar. Waits for a known duration so Discord doesn't keep a first
+  /// payload with no end time (rate-limited).
+  void _pushDiscordWatching() {
+    final discordTitle = showTitle ?? scrobbleTitle;
+    if (discordTitle == null ||
+        discordTitle.isEmpty ||
+        _lastDur <= Duration.zero ||
+        !sl.isRegistered<DiscordRpc>()) {
+      return;
+    }
+    unawaited(
+      sl<DiscordRpc>().setWatching(
+        title: discordTitle,
+        episodeLabel: discordEpisodeLabel(
+          currentEpisode,
+          fallbackNumber: state.currentIndex + 1,
+        ),
+        posterUrl: cover,
+        position: _lastPos,
+        duration: _lastDur,
+        playing: !_discordPaused,
+      ),
+    );
+  }
+
+  Future<void> _enrichEpisodeTitles() async {
+    if (!sl.isRegistered<EpisodeMetadataService>()) return;
+    try {
+      final next = await sl<EpisodeMetadataService>().enrich(
+        episodes: episodes,
+        type: (scrobbleTitle != null || malId != null)
+            ? ProviderType.anime
+            : ProviderType.movie,
+        malId: malId,
+        tmdbId: tmdbId,
+        tmdbIsTv: tmdbIsTv,
+      );
+      if (isClosed || identical(next, episodes)) return;
+      episodes = next;
+    } catch (_) {/* keep source titles */}
+  }
+
   /// Client-mode: apply the host's state without re-broadcasting. Seeks only on
   /// meaningful drift (the controller already gates with needsCorrection).
   Future<void> applyRemote(
@@ -2617,15 +2681,18 @@ class PlayerCubit extends Cubit<PlayerState> {
   @override
   Future<void> close() async {
     await _persist(flush: true);
-    // Leaving the player → drop the "Watching" presence back to browsing.
+    // Leaving the player → drop Watching. Do not immediately restore a
+    // "Playing" browse status; that is what kept the profile occupied after
+    // the episode ended. Detail screens set browsing on their own init.
     if (sl.isRegistered<DiscordRpc>()) {
-      sl<DiscordRpc>().setBrowsing(title: showTitle, posterUrl: cover);
+      sl<DiscordRpc>().clear(delay: DiscordRpc.playerExitClearDelay);
     }
     for (final s in _subs) {
       s.cancel();
     }
     _stallTimer?.cancel();
     _toastTimer?.cancel();
+    _discordPauseTimer?.cancel();
     // Stop any active torrent stream + delete its buffered pieces.
     await _stopTorrent();
     toast.dispose();

--- a/lib/features/player/player_episodes_panel.dart
+++ b/lib/features/player/player_episodes_panel.dart
@@ -1,19 +1,8 @@
 // Episodes side panel.
 part of 'player_screen.dart';
 
-String stripEpisodePrefix(String title, int n) {
-  final t = title.trim();
-  final word = RegExp(
-    '^(?:episode|ep\\.?|e)\\s*0*$n(?![0-9])\\s*[:\\-–—.)\\]]*\\s*',
-    caseSensitive: false,
-  );
-  final bare = RegExp('^0*$n(?![0-9])\\s*[:\\-–—.)\\]]+\\s*');
-  final m = word.firstMatch(t) ?? bare.firstMatch(t);
-  if (m == null) return t;
-  final rest = t.substring(m.end).trim();
-  // Nothing but the marker — let the caller fall back to showing just "E2".
-  return rest;
-}
+String stripEpisodePrefix(String title, int n) =>
+    stripGenericEpisodePrefix(title, n);
 
 // One row in the panel — either a "SEASON n" header or an episode (with its
 // global index into the flat episode list).
@@ -464,8 +453,7 @@ class _EpisodesPanelState extends State<_EpisodesPanel> {
   Widget _card(Episode e, int i, double thumbH, double s, double pad) {
     final cur = i == widget.currentIndex;
     final n = e.number?.toInt() ?? (i + 1);
-    final raw = e.title.trim();
-    final title = stripEpisodePrefix(_multiSeason ? cleanTitle(raw) : raw, n);
+    final title = episodeDisplayTitle(e, number: n) ?? '';
     final hasTitle = title.isNotEmpty;
     final thumb = (e.thumbnail != null && e.thumbnail!.isNotEmpty)
         ? e.thumbnail!

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -23,6 +23,7 @@ import 'subtitle_style.dart';
 import 'subtitle_font_service.dart';
 import '../../core/torrent/torrent_util.dart';
 import '../../core/models/episode.dart';
+import '../../core/models/episode_title.dart';
 import '../../core/models/video_source.dart';
 import '../../core/playback/resume_store.dart';
 import '../../core/playback/source_selection.dart';
@@ -35,8 +36,7 @@ import '../../core/ui/badge.dart';
 import '../../core/ui/brand_loader.dart';
 import '../../core/ui/frosted_surface.dart';
 import '../../core/ui/subtitle_language_picker.dart';
-import '../detail/cubit/detail_cubit.dart'
-    show seasonOf, seasonsOf, cleanTitle;
+import '../detail/cubit/detail_cubit.dart' show seasonOf, seasonsOf;
 import '../../core/cast/cast_controller.dart';
 import '../../core/cast/cast_proxy.dart';
 import '../watch_together/watch_together_controller.dart';

--- a/lib/features/player/tv_exo_controller.dart
+++ b/lib/features/player/tv_exo_controller.dart
@@ -35,7 +35,10 @@ class TvExoController {
     final rawPosition = e['positionMs'];
     final rawDuration = e['durationMs'];
     position.value = rawPosition is num ? rawPosition.toInt() : 0;
-    duration.value = rawDuration is num ? rawDuration.toInt() : 0;
+    // HLS/DASH often emit 0 until the window is known. Don't clobber a real
+    // duration — that would drop Discord's progress bar and resume seeks.
+    final nextDur = rawDuration is num ? rawDuration.toInt() : 0;
+    if (nextDur > 0) duration.value = nextDur;
     playing.value = e['playing'] == true;
     buffering.value = e['buffering'] == true;
     ended.value = e['ended'] == true;
@@ -136,5 +139,11 @@ class TvExoController {
     ended.dispose();
     audioTracks.dispose();
     textTracks.dispose();
+  }
+
+  /// New source / episode — duration is unknown until the next ready event.
+  void resetTimeline() {
+    position.value = 0;
+    duration.value = 0;
   }
 }

--- a/lib/features/player/tv_exo_player_screen.dart
+++ b/lib/features/player/tv_exo_player_screen.dart
@@ -9,8 +9,12 @@ import 'package:flutter/services.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 import '../../core/di/injector.dart';
+import '../../core/discord/discord_presence.dart';
 import '../../core/discord/discord_rpc.dart';
+import '../../core/metadata/episode_metadata_service.dart';
 import '../../core/models/episode.dart';
+import '../../core/models/episode_title.dart';
+import '../../core/models/provider_info.dart';
 import '../../core/models/video_source.dart';
 import '../../core/playback/hls.dart';
 import '../../core/playback/playback_prefs.dart';
@@ -93,9 +97,13 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   // (providers that ship separate lists per language). Seeded from the widget.
   late List<Episode> _episodes;
   int _index = 0;
+  bool _episodesEnriched = false;
   bool _resumeSeeked = false;
   String? _error;
   int _lastSavedMs = 0;
+  int _discordLastPos = 0;
+  Timer? _discordPauseTimer;
+  bool _discordPaused = false;
 
   final _dio = Dio();
   late String _category;
@@ -201,6 +209,8 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     c.position.addListener(_scrobbleTick);
     c.position.addListener(_maybeAutoSkip);
     c.playing.addListener(_onPlayingChanged);
+    c.duration.addListener(_pushDiscordWatchingIfDurationKnown);
+    c.position.addListener(_maybeDiscordSeek);
     _bumpControls();
     _loadEpisode();
   }
@@ -228,10 +238,19 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   void _onPlayingChanged() {
     if (!mounted) return;
     if (_c?.playing.value == true) {
+      _discordPaused = false;
+      _discordPauseTimer?.cancel();
+      _pushDiscordWatchingIfDurationKnown();
       _bumpControls(); // resumed → start the fade-out countdown
     } else {
       _controlsHideTimer?.cancel(); // paused → keep controls up
       if (!_controlsVisible) setState(() => _controlsVisible = true);
+      _discordPauseTimer?.cancel();
+      _discordPauseTimer = Timer(const Duration(milliseconds: 600), () {
+        if (!mounted || _c?.playing.value == true) return;
+        _discordPaused = true;
+        _pushDiscordWatchingIfDurationKnown();
+      });
     }
   }
 
@@ -280,7 +299,33 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
 
   bool _loadErrorDialogOpen = false;
 
+  Future<void> _ensureEpisodeMeta() async {
+    if (_episodesEnriched) return;
+    _episodesEnriched = true;
+    final next = await _enrichList(_episodes);
+    if (!mounted || identical(next, _episodes)) return;
+    _episodes = next;
+  }
+
+  Future<List<Episode>> _enrichList(List<Episode> episodes) async {
+    if (!sl.isRegistered<EpisodeMetadataService>()) return episodes;
+    try {
+      return await sl<EpisodeMetadataService>().enrich(
+        episodes: episodes,
+        type: widget.scrobbleTitle != null || widget.malId != null
+            ? ProviderType.anime
+            : ProviderType.movie,
+        malId: widget.malId,
+        tmdbId: widget.tmdbId,
+        tmdbIsTv: widget.tmdbIsTv,
+      );
+    } catch (_) {
+      return episodes;
+    }
+  }
+
   Future<void> _loadEpisode() async {
+    await _ensureEpisodeMeta();
     final ep = _ep;
     if (ep == null) {
       await _onEpisodeLoadFailed('No episode to play.');
@@ -328,6 +373,7 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     bool keepDownloads = false,
   }) async {
     _activeSource = src;
+    _c?.resetTimeline();
     _resumeSeeked = false;
     _seekTargetMs = seekToMs > 0 ? seekToMs : null;
     if (!keepDownloads) {
@@ -367,35 +413,51 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     // Discord Rich Presence: announce the episode now playing. This screen
     // hosts a native ExoPlayer PlatformView (not PlayerController), so the
     // phone player's setWatching never fired here — mirror it.
-    _announceWatching(_ep);
+    _pushDiscordWatchingIfDurationKnown();
   }
 
-  /// Push a "Watching" Discord presence for [ep] (mirrors the phone player and
-  /// the native TV player). No-op when Discord isn't wired up / no title; the
-  /// service itself also drops it when disabled or incognito.
-  void _announceWatching(Episode? ep) {
+  void _pushDiscordWatchingIfDurationKnown() {
+    if ((_c?.duration.value ?? 0) <= 0) return;
+    _pushDiscordWatching();
+  }
+
+  void _maybeDiscordSeek() {
+    final c = _c;
+    if (c == null) return;
+    final p = c.position.value;
+    if ((p - _discordLastPos).abs() > 3000) {
+      _pushDiscordWatchingIfDurationKnown();
+    }
+    _discordLastPos = p;
+  }
+
+  void _pushDiscordWatching() {
     final title = widget.showTitle;
+    final ep = _ep;
+    final c = _c;
     if (ep == null ||
         title == null ||
         title.isEmpty ||
         !sl.isRegistered<DiscordRpc>()) {
       return;
     }
-    sl<DiscordRpc>().setWatching(
-      title: title,
-      episodeLabel: 'Episode ${(ep.number ?? (_index + 1)).toInt()}',
-      posterUrl: widget.cover,
-      startMs: DateTime.now().millisecondsSinceEpoch,
+    unawaited(
+      sl<DiscordRpc>().setWatching(
+        title: title,
+        episodeLabel: discordEpisodeLabel(ep, fallbackNumber: _index + 1),
+        posterUrl: widget.cover,
+        position: Duration(milliseconds: c?.position.value ?? 0),
+        duration: Duration(milliseconds: c?.duration.value ?? 0),
+        playing: !_discordPaused,
+      ),
     );
   }
 
-  /// Revert presence to "browsing" when the player exits.
+  /// Drop Watching when the player exits so the profile status actually
+  /// disappears (the detail screen underneath will not re-fire browsing).
   void _announceBrowsing() {
     if (!sl.isRegistered<DiscordRpc>()) return;
-    sl<DiscordRpc>().setBrowsing(
-      title: widget.showTitle,
-      posterUrl: widget.cover,
-    );
+    sl<DiscordRpc>().clear(delay: DiscordRpc.playerExitClearDelay);
   }
 
   Future<String?> _resolveTorrent(String uri, int gen) async {
@@ -672,7 +734,7 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
             sourceId: widget.sourceId,
           );
           if (other.isNotEmpty) {
-            newEpisodes = other;
+            newEpisodes = await _enrichList(other);
             newIndex = _index < other.length ? _index : 0;
             epUrl = other[newIndex].url;
           }
@@ -1333,11 +1395,20 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
 
   @override
   void dispose() {
-    _announceBrowsing(); // leaving the player → back to "browsing"
+    // Android pauses (and often disposes) this screen when the Exo surface
+    // attaches — that is not leaving the player. A delayed clear here races
+    // duration and wipes the Discord progress bar.
+    final life = WidgetsBinding.instance.lifecycleState;
+    if (life != AppLifecycleState.paused &&
+        life != AppLifecycleState.hidden &&
+        life != AppLifecycleState.inactive) {
+      _announceBrowsing();
+    }
     _loadGen++; // supersede any in-flight torrent resolve so it stops itself
     _stopTorrent();
     _menuHideTimer?.cancel();
     _controlsHideTimer?.cancel();
+    _discordPauseTimer?.cancel();
     _upNextTimer
         ?.cancel(); // cancel directly — _cancelUpNext setStates/refocuses
     final c = _c;
@@ -1629,9 +1700,7 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     final ep = _ep;
     final epLabel = ep == null
         ? null
-        : (ep.number != null
-              ? 'Episode ${ep.number!.toInt()}'
-              : 'Episode ${_index + 1}');
+        : episodePresenceDetails(ep, fallbackNumber: _index + 1);
     final buttons = <({IconData icon, String label, VoidCallback onTap})>[
       (
         icon: Icons.video_library_outlined,
@@ -1884,9 +1953,9 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
                   itemCount: _episodes.length,
                   itemBuilder: (context, i) {
                     final ep = _episodes[i];
-                    final title = ep.title.isNotEmpty
-                        ? ep.title
-                        : 'Episode ${i + 1}';
+                    final n = ep.number?.toInt() ?? (i + 1);
+                    final title =
+                        episodeDisplayTitle(ep, number: n) ?? 'Episode $n';
                     final current = i == _index;
                     return Padding(
                       padding: const EdgeInsets.only(bottom: 8),

--- a/lib/features/player/tv_native_player.dart
+++ b/lib/features/player/tv_native_player.dart
@@ -1,9 +1,15 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import '../../core/di/injector.dart';
+import '../../core/discord/discord_presence.dart';
 import '../../core/discord/discord_rpc.dart';
+import '../../core/metadata/episode_metadata_service.dart';
 import '../../core/models/episode.dart';
+import '../../core/models/episode_title.dart';
+import '../../core/models/provider_info.dart';
 import '../../core/models/video_source.dart';
 import '../../core/playback/playback_prefs.dart';
 import '../../core/playback/title_prefs.dart';
@@ -72,11 +78,19 @@ class TvNativePlayer {
     List<String> availableCategories = const [],
     int? malId,
     String? scrobbleTitle,
+    int? tmdbId,
+    bool tmdbIsTv = false,
   }) async {
     if (startIndex < 0 || startIndex >= episodes.length) return false;
 
     _resolve = resolveSources;
-    _episodes = episodes;
+    _episodes = await _enrichEpisodes(
+      episodes,
+      malId: malId,
+      tmdbId: tmdbId,
+      tmdbIsTv: tmdbIsTv,
+      anime: scrobbleTitle != null || malId != null,
+    );
     _sourceId = sourceId;
     _showUrl = showUrl;
     _showId = showUrl ?? sourceId;
@@ -92,7 +106,7 @@ class TvNativePlayer {
       _handlerBound = true;
     }
 
-    final ep = episodes[startIndex];
+    final ep = _episodes[startIndex];
     final src = await _resolveSource(ep);
     if (src == null) return false;
     final playUrl = await _playableUrl(src.url);
@@ -114,14 +128,20 @@ class TvNativePlayer {
     // Discord Rich Presence: the native Activity runs outside the Flutter
     // engine and can't reach the Dart Discord service, so announce "Watching"
     // from here — mirroring the phone player (player_controller.dart).
-    _announceWatching(ep);
+    // Wait for native STATE_READY when duration is unknown. Sending Watching
+    // with end=null first is often the update Discord keeps (rate-limited).
+    _announceWatching(
+      ep,
+      positionMs: mark?.position.inMilliseconds ?? 0,
+      durationMs: mark?.duration.inMilliseconds ?? 0,
+    );
 
     final res = await _ch.invokeMapMethod<String, dynamic>('launch', {
       ..._streamPayload(src, mark?.position.inMilliseconds ?? 0),
       'url': playUrl, // torrent → local stream URL; otherwise unchanged
       'title': _showTitle,
       'episodeLabel': _episodeLabel(ep),
-      'episodeLabels': [for (final e in episodes) _episodeLabel(e)],
+      'episodeLabels': [for (final e in _episodes) _episodeLabel(e)],
       'episodeCount': episodes.length,
       'startIndex': startIndex,
       'category': category,
@@ -153,9 +173,8 @@ class TvNativePlayer {
     final posMs = (res?['positionMs'] as num?)?.toInt() ?? 0;
     final durMs = (res?['durationMs'] as num?)?.toInt() ?? 0;
     _saveProgress(index, posMs, durMs);
-    // Player closed → revert presence to "browsing". The detail screen stays
-    // mounted underneath and won't re-fire it, so we must (mirrors
-    // PlayerController.close()).
+    // Player closed → drop Watching, then restore browsing. The detail screen
+    // stays mounted underneath and won't re-fire it.
     _announceBrowsing();
     return true;
   }
@@ -176,7 +195,11 @@ class TvNativePlayer {
         _category = category;
         final mark = _resume?.get(_sourceId, _showId, ep.id);
         // Episode switch / Next Episode → advance the Discord "Watching" line.
-        _announceWatching(ep);
+        _announceWatching(
+          ep,
+          positionMs: mark?.position.inMilliseconds ?? 0,
+          durationMs: mark?.duration.inMilliseconds ?? 0,
+        );
         return {
           ..._streamPayload(src, mark?.position.inMilliseconds ?? 0),
           'url': playUrl,
@@ -184,11 +207,18 @@ class TvNativePlayer {
         };
       case 'saveProgress':
         final args = (call.arguments as Map).cast<String, dynamic>();
-        _saveProgress(
-          (args['index'] as num?)?.toInt() ?? -1,
-          (args['positionMs'] as num?)?.toInt() ?? 0,
-          (args['durationMs'] as num?)?.toInt() ?? 0,
-        );
+        final index = (args['index'] as num?)?.toInt() ?? -1;
+        final posMs = (args['positionMs'] as num?)?.toInt() ?? 0;
+        final durMs = (args['durationMs'] as num?)?.toInt() ?? 0;
+        _saveProgress(index, posMs, durMs);
+        if (index >= 0 && index < _episodes.length) {
+          _announceWatching(
+            _episodes[index],
+            positionMs: posMs,
+            durationMs: durMs,
+            playing: args['playing'] as bool? ?? true,
+          );
+        }
         return null;
       case 'setCategory':
         // The native player switched sub/dub — remember it for this title so the
@@ -389,32 +419,56 @@ class TvNativePlayer {
   /// launch and on every episode switch — same shape as the phone player
   /// (player_controller.dart). No-op when Discord isn't wired up / a title is
   /// missing; the service itself also drops it when disabled/incognito.
-  static void _announceWatching(Episode ep) {
+  static void _announceWatching(
+    Episode ep, {
+    int positionMs = 0,
+    int durationMs = 0,
+    bool playing = true,
+  }) {
     if (_showTitle.isEmpty || !sl.isRegistered<DiscordRpc>()) return;
-    final label = _episodeLabel(ep);
-    sl<DiscordRpc>().setWatching(
-      title: _showTitle,
-      episodeLabel: label.isEmpty ? null : label,
-      posterUrl: _cover,
-      startMs: DateTime.now().millisecondsSinceEpoch,
+    if (durationMs <= 0) return;
+    unawaited(
+      sl<DiscordRpc>().setWatching(
+        title: _showTitle,
+        episodeLabel: discordEpisodeLabel(ep),
+        posterUrl: _cover,
+        position: Duration(milliseconds: positionMs),
+        duration: Duration(milliseconds: durationMs),
+        playing: playing,
+      ),
     );
   }
 
-  /// Revert presence to "browsing" when the player exits.
+  /// Drop Watching when the player exits so the profile status actually
+  /// disappears (the detail screen underneath will not re-fire browsing).
   static void _announceBrowsing() {
     if (!sl.isRegistered<DiscordRpc>()) return;
-    sl<DiscordRpc>().setBrowsing(
-      title: _showTitle.isEmpty ? null : _showTitle,
-      posterUrl: _cover,
-    );
+    sl<DiscordRpc>().clear(delay: DiscordRpc.playerExitClearDelay);
   }
 
-  /// Top-left label under the show title, e.g. "Episode 3". Prefers the episode's
-  /// own title, falling back to its number.
-  static String _episodeLabel(Episode ep) {
-    if (ep.title.trim().isNotEmpty) return ep.title.trim();
-    final n = ep.number;
-    return n == null ? '' : 'Episode ${n % 1 == 0 ? n.toInt() : n}';
+  /// Top-left label under the show title, e.g. "Episode 3 · Real Name".
+  static String _episodeLabel(Episode ep) =>
+      episodePresenceDetails(ep) ?? '';
+
+  static Future<List<Episode>> _enrichEpisodes(
+    List<Episode> episodes, {
+    int? malId,
+    int? tmdbId,
+    bool tmdbIsTv = false,
+    bool anime = false,
+  }) async {
+    if (!sl.isRegistered<EpisodeMetadataService>()) return episodes;
+    try {
+      return await sl<EpisodeMetadataService>().enrich(
+        episodes: episodes,
+        type: anime ? ProviderType.anime : ProviderType.movie,
+        malId: malId,
+        tmdbId: tmdbId,
+        tmdbIsTv: tmdbIsTv,
+      );
+    } catch (_) {
+      return episodes;
+    }
   }
 
   /// Same container→MIME hinting the Flutter player uses (tokenized URLs have no

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -214,9 +214,12 @@ class _WatchAppState extends State<WatchApp> with WidgetsBindingObserver {
     if (state == AppLifecycleState.resumed) {
       discord?.onForeground();
       _syncOnResume();
-    } else if (state == AppLifecycleState.paused ||
-        state == AppLifecycleState.detached) {
-      discord?.onBackground();
+    } else if (state == AppLifecycleState.paused) {
+      // Opening the in-app player (native surface / immersive) fires paused
+      // even though the user is still watching. Do not drop Rich Presence.
+      discord?.onPaused();
+    } else if (state == AppLifecycleState.detached) {
+      discord?.onDetached();
     }
   }
 

--- a/test/core/discord/discord_presence_test.dart
+++ b/test/core/discord/discord_presence_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:watch_app/core/discord/discord_presence.dart';
+
+void main() {
+  final now = DateTime.fromMillisecondsSinceEpoch(1_700_000_000_000);
+
+  group('discordPlaybackTimestamps', () {
+    test('playing with duration yields start+end so Discord can draw a bar', () {
+      final ts = discordPlaybackTimestamps(
+        position: const Duration(minutes: 5),
+        duration: const Duration(minutes: 24),
+        playing: true,
+        now: now,
+      );
+      expect(ts.startMs, now.millisecondsSinceEpoch - 5 * 60 * 1000);
+      expect(ts.endMs, ts.startMs! + 24 * 60 * 1000);
+    });
+
+    test('playing with unknown duration is start-only (elapsed, no bar)', () {
+      final ts = discordPlaybackTimestamps(
+        position: const Duration(seconds: 90),
+        duration: Duration.zero,
+        playing: true,
+        now: now,
+      );
+      expect(ts.startMs, now.millisecondsSinceEpoch - 90 * 1000);
+      expect(ts.endMs, isNull);
+    });
+
+    test('paused omits timestamps so the bar does not keep moving', () {
+      final ts = discordPlaybackTimestamps(
+        position: const Duration(minutes: 5),
+        duration: const Duration(minutes: 24),
+        playing: false,
+        now: now,
+      );
+      expect(ts.startMs, isNull);
+      expect(ts.endMs, isNull);
+    });
+  });
+
+  group('DiscordActivity', () {
+    test('watching payload uses type 3 and both timestamps', () {
+      final json = DiscordActivity(
+        name: 'Frieren',
+        type: 3,
+        details: 'Episode 4',
+        startMs: 100,
+        endMs: 200,
+      ).toJson('app');
+      expect(json['type'], 3);
+      expect(json['name'], 'Frieren');
+      expect(json['timestamps'], {'start': 100, 'end': 200});
+    });
+  });
+
+  group('discordPresenceUpdate', () {
+    test('null activity sends an empty list so the profile status drops', () {
+      final payload = discordPresenceUpdate(null, 'app');
+      expect(payload['activities'], isEmpty);
+    });
+
+    test('watching activity is wrapped as the sole presence', () {
+      const a = DiscordActivity(name: 'Frieren', type: 3);
+      final payload = discordPresenceUpdate(a, 'app');
+      expect(payload['activities'], hasLength(1));
+      expect((payload['activities'] as List).single['type'], 3);
+    });
+  });
+}

--- a/test/core/discord/discord_presence_test.dart
+++ b/test/core/discord/discord_presence_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:watch_app/core/discord/discord_presence.dart';
+import 'package:watch_app/core/models/episode.dart';
 
 void main() {
   final now = DateTime.fromMillisecondsSinceEpoch(1_700_000_000_000);
@@ -36,6 +37,37 @@ void main() {
       );
       expect(ts.startMs, isNull);
       expect(ts.endMs, isNull);
+    });
+  });
+
+  group('discordEpisodeLabel', () {
+    Episode ep({
+      String title = '',
+      double? number,
+      String? metaTitle,
+    }) =>
+        Episode(id: '1', title: title, url: 'u', number: number, metaTitle: metaTitle);
+
+    test('number plus real title', () {
+      expect(
+        discordEpisodeLabel(ep(title: 'Episode 47: The Two Chakra Beasts', number: 47)),
+        'Episode 47 · The Two Chakra Beasts',
+      );
+    });
+
+    test('generic source title uses AniZip/TMDB metaTitle', () {
+      expect(
+        discordEpisodeLabel(ep(title: 'Episode 47', number: 47, metaTitle: 'The Two Chakra Beasts')),
+        'Episode 47 · The Two Chakra Beasts',
+      );
+    });
+
+    test('generic title with no meta is number only', () {
+      expect(discordEpisodeLabel(ep(title: 'Episode 4', number: 4)), 'Episode 4');
+    });
+
+    test('title only when number is missing', () {
+      expect(discordEpisodeLabel(ep(title: 'Movie')), 'Movie');
     });
   });
 

--- a/test/features/player/tv_exo_controller_test.dart
+++ b/test/features/player/tv_exo_controller_test.dart
@@ -22,6 +22,15 @@ void main() {
       c.dispose();
     });
 
+    test('keeps a known duration when a later event still reports 0', () {
+      final c = TvExoController(0);
+      c.applyEvent({'positionMs': 1000, 'durationMs': 90000});
+      c.applyEvent({'positionMs': 2000, 'durationMs': 0});
+      expect(c.duration.value, 90000);
+      expect(c.position.value, 2000);
+      c.dispose();
+    });
+
     test('missing/garbage fields fall back to safe defaults', () {
       final c = TvExoController(0);
       c.applyEvent({'positionMs': 'x', 'playing': null});


### PR DESCRIPTION
## What changed

Discord Rich Presence now uses **Watching** (not Playing), shows a progress bar while an episode is playing, and clears from the profile after you leave the player.

- Gateway stays connected through Android `paused` so native/TV playback does not drop status. Presence is cleared on real player exit (short delay), disable, incognito, or process detach.
- Progress uses Discord `start`/`end` timestamps. Pause omits timestamps so the bar does not keep moving. Watching is not announced until duration is known, and rapid updates are coalesced so Discord does not keep a first `dur=0` payload.
- Wired on phone/iOS, Android TV native, and TV Exo.

**Enhancement (not required for #35):** episode details can include a real title (`Episode 47 · The Title`) when AniZip/TMDB metadata is available. Generic source titles like `Episode 47` still work as number-only. The same title helper is used on detail and player episode lists.

Closes #35

## How you tested it

<!-- Fill in devices and the flows you actually ran. Screenshots below. -->

- [x] Phone / iOS: play an episode, pause, seek, leave the player — presence should show Watching with a bar, freeze on pause, and clear after exit
- [x] Android TV native player: same, plus skip intro / D-pad seek should not look like a pause
- [x] Android TV Exo (if used): pause / background the surface without wiping Watching
- [x] Disable Discord / incognito: presence should not stay on the profile

## Checklist

- [x] `flutter analyze` is clean
- [x] `flutter test` passes
- [x] Native build still compiles, if I touched `android/` or `ios/`
- [x] I've read and agree to the [CLA](../CLA.md)
- [x] New dependency or third-party code? [`NOTICE.md`](../NOTICE.md) updated in this PR
- [x] Used AI tooling? Disclosed per [`AI_POLICY.md`](../AI_POLICY.md)

AI assistance: used Cursor to implement Discord Gateway/RPC, TV/phone presence wiring, and the episode-title helper; reviewed and iterated on pause/duration/clear behavior.

## Screenshots


### Enhanced Episode Titles in Player, which trickles into Discord Presence
<img width="3250" height="1824" alt="CleanShot 2026-08-19 at 16 32 08@2x" src="https://github.com/user-attachments/assets/eaa7c362-107b-423a-acce-d0a311bdceda" />

### Discord Presence with Progress: 
<img width="954" height="524" alt="CleanShot 2026-08-19 at 16 28 40@2x" src="https://github.com/user-attachments/assets/c0743d84-4565-4a0c-8e53-d094a302126e" />

### Sending App Logo when Idle: 
<img width="962" height="560" alt="CleanShot 2026-08-19 at 16 29 04@2x" src="https://github.com/user-attachments/assets/61c458d8-a32f-4a27-8745-0fe325245f63" />

<!-- Drop Discord profile screenshots here (Watching + progress, paused, cleared after exit). -->