### PR TITLE
feat(tv): filler episode badges and skip parity with mobile

### DIFF
--- a/android/app/src/main/kotlin/com/spyou/watch_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/MainActivity.kt
@@ -315,6 +315,13 @@ class MainActivity : FlutterActivity() {
                 ch.setMethodCallHandler { call, result ->
                     when (call.method) {
                         "launch" -> launchTvPlayer(call, result)
+                        "setFillerInfo" -> {
+                            val flags = call.argument<List<*>>("fillerFlags")
+                                ?.map { it == true }?.toBooleanArray()
+                            val auto = call.argument<Boolean>("autoSkipFiller")
+                            TvPlayerActivity.active?.applyFillerInfo(flags, auto)
+                            result.success(null)
+                        }
                         else -> result.notImplemented()
                     }
                 }
@@ -1210,6 +1217,16 @@ class MainActivity : FlutterActivity() {
             intent.putExtra(TvPlayerActivity.EXTRA_SKIP_INTRO, call.argument<Boolean>("skipIntro") ?: true)
             intent.putExtra(TvPlayerActivity.EXTRA_AUTO_SKIP_OP, call.argument<Boolean>("autoSkipOp") ?: false)
             intent.putExtra(TvPlayerActivity.EXTRA_AUTO_SKIP_ED, call.argument<Boolean>("autoSkipEd") ?: false)
+            intent.putExtra(
+                TvPlayerActivity.EXTRA_AUTO_SKIP_FILLER,
+                call.argument<Boolean>("autoSkipFiller") ?: false,
+            )
+            call.argument<List<*>>("fillerFlags")?.let { raw ->
+                intent.putExtra(
+                    TvPlayerActivity.EXTRA_FILLER_FLAGS,
+                    raw.map { it == true }.toBooleanArray(),
+                )
+            }
 
             val headers = call.argument<Map<String, String>>("headers")
             if (!headers.isNullOrEmpty()) {

--- a/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
@@ -474,9 +474,10 @@ class TvPlayerActivity : Activity() {
     }
 
     /**
-     * Next index for binge autoplay. When [autoSkipFiller] is on, jumps past
-     * consecutive fillers — but never strands the user (if everything left is
-     * filler, returns immediate next). Mirrors Dart [nextAutoplayIndex].
+     * Next index when advancing (autoplay or Next button). When
+     * [autoSkipFiller] is on, jumps past consecutive fillers — but never
+     * strands the user (if everything left is filler, returns immediate next).
+     * Mirrors Dart [nextAutoplayIndex].
      */
     private fun nextAutoplayIndex(): Int {
         val immediate = currentIndex + 1
@@ -1180,7 +1181,7 @@ class TvPlayerActivity : Activity() {
         btnQuality.setOnClickListener { openQualityMenu() }
         btnSources.setOnClickListener { openSourcesMenu() }
         btnAudioSubs.setOnClickListener { openAvMenu() }
-        btnNext.setOnClickListener { loadEpisode(currentIndex + 1) }
+        btnNext.setOnClickListener { loadEpisode(nextAutoplayIndex()) }
         btnMegaskip.setOnClickListener { seekBy(megaSkipSecs * 1000L) }
 
         skipButton.isFocusableInTouchMode = true

--- a/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
@@ -89,6 +89,8 @@ class TvPlayerActivity : Activity() {
         const val EXTRA_SKIP_INTRO = "skipIntro"
         const val EXTRA_AUTO_SKIP_OP = "autoSkipOp"
         const val EXTRA_AUTO_SKIP_ED = "autoSkipEd"
+        const val EXTRA_AUTO_SKIP_FILLER = "autoSkipFiller"
+        const val EXTRA_FILLER_FLAGS = "fillerFlags"
         // Result extras read back in MainActivity.onActivityResult.
         const val RESULT_POSITION = "positionMs"
         const val RESULT_DURATION = "durationMs"
@@ -99,6 +101,11 @@ class TvPlayerActivity : Activity() {
         private const val HOLD_MS = 500L
         private const val DEFAULT_ACCENT = 0xFFFF4D5E.toInt()
         private const val UNFOCUSED_PILL = 0x59101014 // subtle dark glass (premium)
+
+        /** Foreground native player, so Dart can push late filler info. */
+        @JvmStatic
+        @Volatile
+        var active: TvPlayerActivity? = null
     }
 
     private var player: ExoPlayer? = null
@@ -155,11 +162,16 @@ class TvPlayerActivity : Activity() {
     // Jump past the OP/ED without a press (Settings toggles, both off by default).
     private var autoSkipOp = false
     private var autoSkipEd = false
+    // Auto-skip filler episodes on binge advance (Settings toggle).
+    private var autoSkipFiller = false
+    // Per-index filler flags from Jikan (via Dart). Empty until launch / update.
+    private var fillerFlags: BooleanArray = BooleanArray(0)
     // Interval starts already auto-skipped for the current episode, so seeking
     // back into an opening you meant to watch doesn't bounce you out again.
     private val autoSkipped = HashSet<Long>()
     // Live subtitle size multiplier (seeded from prefs; changeable in-player).
     private var subScale = 1f
+    private lateinit var fillerBadge: TextView
 
     private lateinit var menuPanel: View
     private lateinit var menuContent: android.widget.LinearLayout
@@ -221,12 +233,15 @@ class TvPlayerActivity : Activity() {
         skipIntroEnabled = intent.getBooleanExtra(EXTRA_SKIP_INTRO, true)
         autoSkipOp = intent.getBooleanExtra(EXTRA_AUTO_SKIP_OP, false)
         autoSkipEd = intent.getBooleanExtra(EXTRA_AUTO_SKIP_ED, false)
+        autoSkipFiller = intent.getBooleanExtra(EXTRA_AUTO_SKIP_FILLER, false)
+        fillerFlags = intent.getBooleanArrayExtra(EXTRA_FILLER_FLAGS) ?: BooleanArray(0)
         subScale = intent.getFloatExtra(EXTRA_SUB_SCALE, 1f)
         subtitleApiKeySet = intent.getBooleanExtra(EXTRA_SUB_HAS_KEY, false)
 
         setContentView(R.layout.tv_player)
         bindViews()
         styleControls()
+        active = this
         // Android 13+ (the tester's Bravia) routes Back through the predictive-back
         // dispatcher — the app opts in app-wide via enableOnBackInvokedCallback=true
         // — which finishes this Activity WITHOUT ever calling dispatchKeyEvent or
@@ -283,9 +298,10 @@ class TvPlayerActivity : Activity() {
                 // Duration is known once ready → fetch AniSkip for this episode.
                 if (state == Player.STATE_READY && skipsFetchedFor != currentIndex) fetchSkips()
                 if (state == Player.STATE_READY) reportTimingIfNeeded()
-                // Autoplay the next episode when this one finishes.
+                // Autoplay the next episode when this one finishes. Honour
+                // auto-skip filler the same way the Flutter player does.
                 if (state == Player.STATE_ENDED && !switching && currentIndex < episodeCount - 1) {
-                    loadEpisode(currentIndex + 1)
+                    loadEpisode(nextAutoplayIndex())
                 }
             }
         })
@@ -440,10 +456,41 @@ class TvPlayerActivity : Activity() {
             text = label
             visibility = if (label.isBlank()) View.GONE else View.VISIBLE
         }
+        val isFiller = currentIndex < fillerFlags.size && fillerFlags[currentIndex]
+        fillerBadge.visibility = if (isFiller) View.VISIBLE else View.GONE
         val hasNext = currentIndex < episodeCount - 1
         btnNext.isEnabled = hasNext
         btnNext.isFocusable = hasNext
         btnNext.alpha = if (hasNext) 1f else 0.35f
+    }
+
+    /** Late filler info from Dart (Jikan fetch finished after launch). */
+    fun applyFillerInfo(flags: BooleanArray?, autoSkip: Boolean?) {
+        runOnUiThread {
+            if (flags != null) fillerFlags = flags
+            if (autoSkip != null) autoSkipFiller = autoSkip
+            updateEpisodeUi()
+        }
+    }
+
+    /**
+     * Next index for binge autoplay. When [autoSkipFiller] is on, jumps past
+     * consecutive fillers — but never strands the user (if everything left is
+     * filler, returns immediate next). Mirrors Dart [nextAutoplayIndex].
+     */
+    private fun nextAutoplayIndex(): Int {
+        val immediate = currentIndex + 1
+        if (immediate >= episodeCount) return immediate
+        if (!autoSkipFiller || fillerFlags.isEmpty()) return immediate
+        var target = immediate
+        while (target < episodeCount &&
+            target < fillerFlags.size &&
+            fillerFlags[target]
+        ) {
+            target++
+        }
+        if (target >= episodeCount) return immediate
+        return target
     }
 
     /** Push position+duration to Dart (Discord bar + resume). */
@@ -694,7 +741,9 @@ class TvPlayerActivity : Activity() {
         sectionHeader("Episodes")
         for (i in 0 until episodeCount) {
             val label = episodeLabels.getOrNull(i) ?: "Episode ${i + 1}"
-            option(label, selected = i == currentIndex) { if (i != currentIndex) loadEpisode(i) }
+            val isFiller = i < fillerFlags.size && fillerFlags[i]
+            val row = if (isFiller) "$label  · FILLER" else label
+            option(row, selected = i == currentIndex) { if (i != currentIndex) loadEpisode(i) }
         }
         showPanel()
         // Land focus on the current episode (row index = currentIndex + 1 header).
@@ -1093,6 +1142,7 @@ class TvPlayerActivity : Activity() {
         btnAudioSubs = findViewById(R.id.btn_audio_subs)
         btnNext = findViewById(R.id.btn_next)
         btnMegaskip = findViewById(R.id.btn_megaskip)
+        fillerBadge = findViewById(R.id.filler_badge)
         // MegaSkip pill: label + visibility from the megaSkip prefs (launch extras).
         megaSkipSecs = intent.getIntExtra(EXTRA_MEGASKIP_SECS, 85)
         btnMegaskip.text = "+${megaSkipSecs}s"
@@ -1100,7 +1150,7 @@ class TvPlayerActivity : Activity() {
             if (intent.getBooleanExtra(EXTRA_MEGASKIP, true)) View.VISIBLE else View.GONE
 
         findViewById<TextView>(R.id.title).text = intent.getStringExtra(EXTRA_TITLE) ?: ""
-        // episode_label is set by updateEpisodeUi (drives off episodeLabels).
+        // episode_label / filler badge are set by updateEpisodeUi.
     }
 
     private fun styleControls() {
@@ -1510,6 +1560,7 @@ class TvPlayerActivity : Activity() {
     }
 
     override fun onDestroy() {
+        if (active === this) active = null
         super.onDestroy()
         handler.removeCallbacksAndMessages(null)
         try { loudness?.release() } catch (_: Exception) {}

--- a/android/app/src/main/res/drawable/tv_filler_badge.xml
+++ b/android/app/src/main/res/drawable/tv_filler_badge.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#26FF4D5E" />
+    <corners android:radius="6dp" />
+</shape>

--- a/android/app/src/main/res/layout/tv_player.xml
+++ b/android/app/src/main/res/layout/tv_player.xml
@@ -111,6 +111,23 @@
                 android:layout_marginTop="2dp"
                 android:textColor="#CCFFFFFF"
                 android:textSize="15sp" />
+
+            <TextView
+                android:id="@+id/filler_badge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:background="@drawable/tv_filler_badge"
+                android:paddingLeft="8dp"
+                android:paddingRight="8dp"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:text="FILLER"
+                android:textColor="#FFFF4D5E"
+                android:textSize="11sp"
+                android:textStyle="bold"
+                android:visibility="gone"
+                tools:ignore="HardcodedText" />
         </LinearLayout>
 
         <!-- Top-right header quick actions (JioHotstar-style small buttons) -->

--- a/lib/core/playback/filler_service.dart
+++ b/lib/core/playback/filler_service.dart
@@ -5,13 +5,13 @@ import 'package:flutter/foundation.dart';
 
 import '../models/episode.dart';
 
-/// Next episode index for binge autoplay. When [autoSkipFiller] is on and
+/// Next episode index when advancing. When [autoSkipFiller] is on and
 /// [fillerEps] is non-empty, jumps past consecutive filler episodes — but
 /// never strands the user (if everything left is filler, returns [currentIndex]
 /// + 1). Returns null when there is no next episode.
 ///
-/// Manual Next should call this with [autoSkipFiller] false so fillers stay
-/// reachable; only auto-advance / up-next passes true (and the pref).
+/// Used for both autoplay and the Next control when the pref is on; pick a
+/// specific episode from the list to still play filler.
 int? nextAutoplayIndex({
   required int currentIndex,
   required List<Episode> episodes,

--- a/lib/core/playback/filler_service.dart
+++ b/lib/core/playback/filler_service.dart
@@ -1,6 +1,34 @@
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/episode.dart';
+
+/// Next episode index for binge autoplay. When [autoSkipFiller] is on and
+/// [fillerEps] is non-empty, jumps past consecutive filler episodes — but
+/// never strands the user (if everything left is filler, returns [currentIndex]
+/// + 1). Returns null when there is no next episode.
+///
+/// Manual Next should call this with [autoSkipFiller] false so fillers stay
+/// reachable; only auto-advance / up-next passes true (and the pref).
+int? nextAutoplayIndex({
+  required int currentIndex,
+  required List<Episode> episodes,
+  required Set<int> fillerEps,
+  required bool autoSkipFiller,
+}) {
+  final immediate = currentIndex + 1;
+  if (immediate >= episodes.length) return null;
+  if (!autoSkipFiller || fillerEps.isEmpty) return immediate;
+  var target = immediate;
+  while (target < episodes.length &&
+      fillerEps.contains(episodes[target].number?.toInt())) {
+    target++;
+  }
+  if (target >= episodes.length) return immediate;
+  return target;
+}
 
 /// Fetches the set of FILLER episode numbers for an anime from Jikan (the MAL
 /// API): `api.jikan.moe/v4/anime/{malId}/episodes` returns a `filler` boolean
@@ -31,6 +59,22 @@ class FillerService {
       _inflight.remove(malId);
     });
   }
+
+  /// Warm the in-memory cache without a network call (tests).
+  @visibleForTesting
+  void debugSeedCache(int malId, Set<int> fillers) {
+    _cache[malId] = fillers;
+  }
+
+  /// Drop the in-memory cache (tests).
+  @visibleForTesting
+  void debugClearCache() {
+    _cache.clear();
+    _inflight.clear();
+  }
+
+  /// Synchronous peek of a warm cache entry (null if not fetched yet).
+  Set<int>? peekCache(int malId) => _cache[malId];
 
   Future<Set<int>> _fetch(int malId) async {
     final fillers = <int>{};

--- a/lib/core/playback/playback_prefs.dart
+++ b/lib/core/playback/playback_prefs.dart
@@ -365,7 +365,8 @@ class PlaybackPrefs {
   int get colorHue => (_box.get('colorHue', defaultValue: 0) as num).toInt();
   Future<void> setColorHue(int v) => _box.put('colorHue', v);
 
-  /// Skip filler episodes on auto-advance (anime only; needs MAL/filler data).
+  /// Skip filler episodes when advancing to the next one (anime only; needs
+  /// MAL/filler data). Applies to autoplay and the Next button.
   /// Off by default.
   bool get autoSkipFiller =>
       _box.get('autoSkipFiller', defaultValue: false) as bool;

--- a/lib/features/detail/detail_screen_tv.dart
+++ b/lib/features/detail/detail_screen_tv.dart
@@ -39,6 +39,18 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
   // leanback keyboard, applies on Done/submit, and hands focus back cleanly.
   String _epQuery = '';
 
+  // Filler episode numbers (from Jikan by MAL id), for the "FILLER" badge —
+  // mirrors phone [_DetailViewState._fillerEps].
+  Set<int> _fillerEps = const {};
+  int? _fillerForMal;
+  void _ensureFiller(int? malId) {
+    if (malId == null || malId == _fillerForMal) return;
+    _fillerForMal = malId;
+    FillerService.instance.fillerEpisodes(malId).then((s) {
+      if (mounted && s.isNotEmpty) setState(() => _fillerEps = s);
+    });
+  }
+
   Future<void> _openEpisodeSearch() async {
     final ctrl = TextEditingController(text: _epQuery);
     final result = await showDialog<String>(
@@ -546,6 +558,8 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     final category = state.category;
     final eps = detail.episodes;
     final store = sl<ResumeStore>();
+    // Kick the (cached, once-per-malId) filler lookup for the FILLER badge.
+    _ensureFiller(detail.malId ?? item.malId);
     // Once-per-detail tracker-progress lookup for episode grey-out.
     _maybeFetchTrackerProgress(detail);
 
@@ -873,6 +887,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                 key: const ValueKey('tv-detail-episodes'),
                                 eps: eps,
                                 seasonEps: seasonEps,
+                                fillerEps: _fillerEps,
                                 query: _epQuery,
                                 hasMultipleSeasons: hasMultipleSeasons,
                                 seasonSet: seasonSet,
@@ -955,6 +970,7 @@ class _TvEpisodeList extends StatelessWidget {
     super.key,
     required this.eps,
     required this.seasonEps,
+    required this.fillerEps,
     required this.hasMultipleSeasons,
     required this.seasonSet,
     required this.currentSeason,
@@ -974,6 +990,7 @@ class _TvEpisodeList extends StatelessWidget {
 
   final List<Episode> eps;
   final List<Episode> seasonEps;
+  final Set<int> fillerEps;
   final bool hasMultipleSeasons;
   final Set<int> seasonSet;
   final int currentSeason;
@@ -1072,6 +1089,7 @@ class _TvEpisodeList extends StatelessWidget {
                   ep: ep,
                   epNum: epNum,
                   displayTitle: displayTitle,
+                  filler: widget.fillerEps.contains(epNum),
                   coverUrl: widget.coverUrl,
                   coverHeaders: widget.coverHeaders,
                   isWatched: watched,

--- a/lib/features/player/player_controller.dart
+++ b/lib/features/player/player_controller.dart
@@ -2255,15 +2255,16 @@ class PlayerCubit extends Cubit<PlayerState> {
     return n != null && _fillerEps.contains(n);
   }
 
-  /// Advance to the next episode. On an AUTO advance (up-next) with "Auto-skip
-  /// filler" on, jumps past consecutive filler episodes — but never strands the
-  /// user (if everything left is filler, it just plays the next one).
+  /// Advance to the next episode. When "Auto-skip filler" is on, jumps past
+  /// consecutive filler episodes — but never strands the user (if everything
+  /// left is filler, it just plays the next one). Same rule for autoplay and
+  /// the Next button; pick an episode from the list to still watch filler.
   Future<void> playNext({bool auto = false}) async {
     final target = nextAutoplayIndex(
       currentIndex: state.currentIndex,
       episodes: episodes,
       fillerEps: _fillerEps,
-      autoSkipFiller: auto && sl<PlaybackPrefs>().autoSkipFiller,
+      autoSkipFiller: sl<PlaybackPrefs>().autoSkipFiller,
     );
     if (target == null) return;
     await openEpisode(target);

--- a/lib/features/player/player_controller.dart
+++ b/lib/features/player/player_controller.dart
@@ -2259,18 +2259,13 @@ class PlayerCubit extends Cubit<PlayerState> {
   /// filler" on, jumps past consecutive filler episodes — but never strands the
   /// user (if everything left is filler, it just plays the next one).
   Future<void> playNext({bool auto = false}) async {
-    final immediate = state.currentIndex + 1;
-    if (immediate >= episodes.length) return;
-    var target = immediate;
-    if (auto &&
-        sl<PlaybackPrefs>().autoSkipFiller &&
-        _fillerEps.isNotEmpty) {
-      while (target < episodes.length &&
-          _fillerEps.contains(episodes[target].number?.toInt())) {
-        target++;
-      }
-      if (target >= episodes.length) target = immediate;
-    }
+    final target = nextAutoplayIndex(
+      currentIndex: state.currentIndex,
+      episodes: episodes,
+      fillerEps: _fillerEps,
+      autoSkipFiller: auto && sl<PlaybackPrefs>().autoSkipFiller,
+    );
+    if (target == null) return;
     await openEpisode(target);
   }
 

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -1484,7 +1484,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
   void _playUpNext() {
     _upNextTimer?.cancel();
     setState(() => _upNext = false);
-    _c.playNext(auto: true); // binge flow → honour "Auto-skip filler"
+    _c.playNext(auto: true); // binge / Next both honour "Auto-skip filler"
   }
 
   void _dismissUpNext() {

--- a/lib/features/player/tv_exo_player_screen.dart
+++ b/lib/features/player/tv_exo_player_screen.dart
@@ -1288,14 +1288,14 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     _rootFocus.requestFocus(); // hand D-pad back to the player
   }
 
-  /// Advance to the next episode. [auto] true (up-next / binge) honours
-  /// auto-skip filler; the on-screen Next button stays manual.
+  /// Advance to the next episode. When auto-skip filler is on, jumps past
+  /// consecutive fillers for both up-next and the Next button.
   void _next({bool auto = false}) {
     final target = nextAutoplayIndex(
       currentIndex: _index,
       episodes: _episodes,
       fillerEps: _fillerEps.value,
-      autoSkipFiller: auto && sl<PlaybackPrefs>().autoSkipFiller,
+      autoSkipFiller: sl<PlaybackPrefs>().autoSkipFiller,
     );
     if (target == null) return;
     setState(() => _index = target);

--- a/lib/features/player/tv_exo_player_screen.dart
+++ b/lib/features/player/tv_exo_player_screen.dart
@@ -16,6 +16,7 @@ import '../../core/models/episode.dart';
 import '../../core/models/episode_title.dart';
 import '../../core/models/provider_info.dart';
 import '../../core/models/video_source.dart';
+import '../../core/playback/filler_service.dart';
 import '../../core/playback/hls.dart';
 import '../../core/playback/playback_prefs.dart';
 import '../../core/playback/resume_store.dart';
@@ -38,6 +39,7 @@ import '../../core/tracker/tracker_hub.dart';
 import '../../core/tv/tv_focusable.dart';
 import '../../core/tv/tv_keys.dart';
 import '../../core/tv/tv_load_error_dialog.dart';
+import '../../core/ui/badge.dart';
 import '../../core/ui/subtitle_language_picker.dart';
 import 'tv_exo_controller.dart';
 import 'tv_track_menu.dart';
@@ -160,6 +162,10 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   Timer? _controlsHideTimer;
   bool _holdingSpeed = false; // D-pad RIGHT held → temporary 2× (YouTube-style)
 
+  /// Filler episode NUMBERS from Jikan (same as phone player). Empty until
+  /// fetched / for non-anime. Drives auto-skip and FILLER badges.
+  final ValueNotifier<Set<int>> _fillerEps = ValueNotifier(const {});
+
   // One remote Back press can arrive TWICE: the overlay's key handler closes
   // it on key-DOWN, then the press still falls through as a route pop, whose
   // ladder — seeing the overlay already closed — would eat the NEXT rung and
@@ -191,7 +197,24 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     // devices don't drop into a screensaver/daydream mid-episode. Gated by the
     // same user pref; released in dispose().
     if (sl<PlaybackPrefs>().keepScreenOn) WakelockPlus.enable();
+    _ensureFiller();
   }
+
+  void _ensureFiller() {
+    final id = widget.malId;
+    if (id == null) return;
+    FillerService.instance.fillerEpisodes(id).then((s) {
+      if (mounted) _fillerEps.value = s;
+    });
+  }
+
+  /// Index the up-next / autoplay path will open (honours auto-skip filler).
+  int? get _autoNextIndex => nextAutoplayIndex(
+        currentIndex: _index,
+        episodes: _episodes,
+        fillerEps: _fillerEps.value,
+        autoSkipFiller: sl<PlaybackPrefs>().autoSkipFiller,
+      );
 
   Episode? get _ep => _episodes.isEmpty ? null : _episodes[_index];
 
@@ -1250,7 +1273,7 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
       if (next <= 0) {
         t.cancel();
         _cancelUpNext();
-        _next();
+        _next(auto: true);
       } else {
         setState(() => _upNextCountdown = next);
       }
@@ -1265,9 +1288,17 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     _rootFocus.requestFocus(); // hand D-pad back to the player
   }
 
-  void _next() {
-    if (_index >= _episodes.length - 1) return;
-    setState(() => _index++);
+  /// Advance to the next episode. [auto] true (up-next / binge) honours
+  /// auto-skip filler; the on-screen Next button stays manual.
+  void _next({bool auto = false}) {
+    final target = nextAutoplayIndex(
+      currentIndex: _index,
+      episodes: _episodes,
+      fillerEps: _fillerEps.value,
+      autoSkipFiller: auto && sl<PlaybackPrefs>().autoSkipFiller,
+    );
+    if (target == null) return;
+    setState(() => _index = target);
     _loadEpisode();
   }
 
@@ -1440,6 +1471,7 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
       n.dispose();
     }
     _episodesScope.dispose();
+    _fillerEps.dispose();
     super.dispose();
   }
 
@@ -1614,7 +1646,7 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
                     },
                   ),
                 ),
-              if (_upNextCountdown != null && _index < _episodes.length - 1)
+              if (_upNextCountdown != null && _autoNextIndex != null)
                 Positioned(
                   right: 40,
                   bottom: 160,
@@ -1624,7 +1656,7 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
                       if (e is! KeyDownEvent) return KeyEventResult.ignored;
                       if (okKeys.contains(e.logicalKey)) {
                         _cancelUpNext();
-                        _next();
+                        _next(auto: true);
                         return KeyEventResult.handled;
                       }
                       if (e.logicalKey == LogicalKeyboardKey.goBack ||
@@ -1634,34 +1666,45 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
                       }
                       return KeyEventResult.ignored;
                     },
-                    child: Container(
-                      padding: const EdgeInsets.all(20),
-                      decoration: BoxDecoration(
-                        color: Colors.black.withValues(alpha: 0.85),
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(color: AppColors.accent, width: 2),
-                      ),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'Up next: ${_episodes[_index + 1].title.isNotEmpty ? _episodes[_index + 1].title : 'Episode ${_index + 2}'}',
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                            ),
+                    child: Builder(
+                      builder: (context) {
+                        final nextIdx = _autoNextIndex!;
+                        final nextEp = _episodes[nextIdx];
+                        final n = nextEp.number?.toInt() ?? (nextIdx + 1);
+                        final nextTitle =
+                            episodeDisplayTitle(nextEp, number: n) ??
+                            'Episode $n';
+                        return Container(
+                          padding: const EdgeInsets.all(20),
+                          decoration: BoxDecoration(
+                            color: Colors.black.withValues(alpha: 0.85),
+                            borderRadius: BorderRadius.circular(12),
+                            border:
+                                Border.all(color: AppColors.accent, width: 2),
                           ),
-                          const SizedBox(height: 8),
-                          Text(
-                            'Playing in $_upNextCountdown…  (OK to play now, Back to cancel)',
-                            style: const TextStyle(
-                              color: Colors.white70,
-                              fontSize: 13,
-                            ),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Up next: $nextTitle',
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              Text(
+                                'Playing in $_upNextCountdown…  (OK to play now, Back to cancel)',
+                                style: const TextStyle(
+                                  color: Colors.white70,
+                                  fontSize: 13,
+                                ),
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
+                        );
+                      },
                     ),
                   ),
                 ),
@@ -1746,12 +1789,27 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
                 ),
                 if (epLabel != null) ...[
                   const SizedBox(height: 4),
-                  Text(
-                    epLabel,
-                    style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.7),
-                      fontSize: 16,
-                    ),
+                  ValueListenableBuilder<Set<int>>(
+                    valueListenable: _fillerEps,
+                    builder: (context, fillers, _) {
+                      final n = ep?.number?.toInt();
+                      final isFiller = n != null && fillers.contains(n);
+                      return Row(
+                        children: [
+                          Text(
+                            epLabel,
+                            style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.7),
+                              fontSize: 16,
+                            ),
+                          ),
+                          if (isFiller) ...[
+                            const SizedBox(width: 8),
+                            const TagBadge(text: 'FILLER'),
+                          ],
+                        ],
+                      );
+                    },
                   ),
                 ],
               ],
@@ -1952,59 +2010,69 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
             Expanded(
               child: FocusScope(
                 node: _episodesScope,
-                child: ListView.builder(
-                  // Big cache so D-pad traversal can reach off-screen rows.
-                  cacheExtent: 2000,
-                  itemCount: _episodes.length,
-                  itemBuilder: (context, i) {
-                    final ep = _episodes[i];
-                    final n = ep.number?.toInt() ?? (i + 1);
-                    final title =
-                        episodeDisplayTitle(ep, number: n) ?? 'Episode $n';
-                    final current = i == _index;
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 8),
-                      child: TvFocusable(
-                        autofocus: current,
-                        scale: 1.0,
-                        onTap: () => _playEpisodeAt(i),
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 20,
-                            vertical: 14,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Colors.white.withValues(alpha: 0.06),
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          child: Row(
-                            children: [
-                              if (current) ...[
-                                const Icon(
-                                  Icons.play_arrow_rounded,
-                                  color: Colors.white,
-                                  size: 20,
-                                ),
-                                const SizedBox(width: 8),
-                              ],
-                              Expanded(
-                                child: Text(
-                                  '${i + 1}. $title',
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 16,
-                                    fontWeight: current
-                                        ? FontWeight.w700
-                                        : FontWeight.w500,
-                                  ),
-                                ),
+                child: ValueListenableBuilder<Set<int>>(
+                  valueListenable: _fillerEps,
+                  builder: (context, fillers, _) {
+                    return ListView.builder(
+                      // Big cache so D-pad traversal can reach off-screen rows.
+                      cacheExtent: 2000,
+                      itemCount: _episodes.length,
+                      itemBuilder: (context, i) {
+                        final ep = _episodes[i];
+                        final n = ep.number?.toInt() ?? (i + 1);
+                        final title =
+                            episodeDisplayTitle(ep, number: n) ?? 'Episode $n';
+                        final current = i == _index;
+                        final isFiller = fillers.contains(n);
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: TvFocusable(
+                            autofocus: current,
+                            scale: 1.0,
+                            onTap: () => _playEpisodeAt(i),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 20,
+                                vertical: 14,
                               ),
-                            ],
+                              decoration: BoxDecoration(
+                                color: Colors.white.withValues(alpha: 0.06),
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              child: Row(
+                                children: [
+                                  if (current) ...[
+                                    const Icon(
+                                      Icons.play_arrow_rounded,
+                                      color: Colors.white,
+                                      size: 20,
+                                    ),
+                                    const SizedBox(width: 8),
+                                  ],
+                                  Expanded(
+                                    child: Text(
+                                      '${i + 1}. $title',
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 16,
+                                        fontWeight: current
+                                            ? FontWeight.w700
+                                            : FontWeight.w500,
+                                      ),
+                                    ),
+                                  ),
+                                  if (isFiller) ...[
+                                    const SizedBox(width: 8),
+                                    const TagBadge(text: 'FILLER'),
+                                  ],
+                                ],
+                              ),
+                            ),
                           ),
-                        ),
-                      ),
+                        );
+                      },
                     );
                   },
                 ),

--- a/lib/features/player/tv_native_player.dart
+++ b/lib/features/player/tv_native_player.dart
@@ -11,6 +11,7 @@ import '../../core/models/episode.dart';
 import '../../core/models/episode_title.dart';
 import '../../core/models/provider_info.dart';
 import '../../core/models/video_source.dart';
+import '../../core/playback/filler_service.dart';
 import '../../core/playback/playback_prefs.dart';
 import '../../core/playback/title_prefs.dart';
 import '../../core/playback/resume_store.dart';
@@ -136,6 +137,27 @@ class TvNativePlayer {
       durationMs: mark?.duration.inMilliseconds ?? 0,
     );
 
+    // Filler flags: use warm cache immediately so launch isn't blocked; push an
+    // update over the channel if the Jikan fetch lands after the player is up.
+    final warm = malId != null
+        ? FillerService.instance.peekCache(malId)
+        : null;
+    final fillerFlags = _fillerFlags(_episodes, warm ?? const {});
+    if (malId != null) {
+      unawaited(
+        FillerService.instance.fillerEpisodes(malId).then((s) async {
+          if (s.isEmpty && warm == null) return;
+          final flags = _fillerFlags(_episodes, s);
+          try {
+            await _ch.invokeMethod<void>('setFillerInfo', {
+              'fillerFlags': flags,
+              'autoSkipFiller': prefs.autoSkipFiller,
+            });
+          } catch (_) {}
+        }),
+      );
+    }
+
     final res = await _ch.invokeMapMethod<String, dynamic>('launch', {
       ..._streamPayload(src, mark?.position.inMilliseconds ?? 0),
       'url': playUrl, // torrent → local stream URL; otherwise unchanged
@@ -163,6 +185,8 @@ class TvNativePlayer {
       'skipIntro': prefs.skipIntro,
       'autoSkipOp': prefs.autoSkipOp,
       'autoSkipEd': prefs.autoSkipEd,
+      'autoSkipFiller': prefs.autoSkipFiller,
+      'fillerFlags': fillerFlags,
     });
 
     // Player closed — stop any active torrent stream.
@@ -449,6 +473,16 @@ class TvNativePlayer {
   /// Top-left label under the show title, e.g. "Episode 3 · Real Name".
   static String _episodeLabel(Episode ep) =>
       episodePresenceDetails(ep) ?? '';
+
+  /// Per-index filler flags for the native player (Jikan episode numbers).
+  static List<bool> _fillerFlags(List<Episode> episodes, Set<int> fillers) {
+    if (fillers.isEmpty) {
+      return List<bool>.filled(episodes.length, false);
+    }
+    return [
+      for (final e in episodes) fillers.contains(e.number?.toInt()),
+    ];
+  }
 
   /// How long playback will wait on episode-name metadata before giving up.
   /// Warm cache returns instantly; this only bites on a cold, slow fetch.

--- a/lib/features/settings/settings_playback.dart
+++ b/lib/features/settings/settings_playback.dart
@@ -795,7 +795,8 @@ class _PlaybackSettingsScreenState extends State<PlaybackSettingsScreen> {
               _toggleRow(
                 icon: Icons.fast_forward_outlined,
                 title: 'Auto-skip filler episodes',
-                subtitle: 'On autoplay, jump past filler (anime only)',
+                subtitle: 'Jump past filler when going to the next episode '
+                    '(anime only)',
                 value: _prefs.autoSkipFiller,
                 onChanged: (v) async {
                   await _prefs.setAutoSkipFiller(v);

--- a/test/core/playback/next_autoplay_index_test.dart
+++ b/test/core/playback/next_autoplay_index_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:watch_app/core/models/episode.dart';
+import 'package:watch_app/core/playback/filler_service.dart';
+
+Episode _ep(int n) => Episode(
+      id: 'e$n',
+      title: 'Episode $n',
+      number: n.toDouble(),
+      url: 'https://example.com/$n',
+    );
+
+void main() {
+  final eps = [_ep(1), _ep(2), _ep(3), _ep(4), _ep(5)];
+
+  group('nextAutoplayIndex', () {
+    test('returns null at end of list', () {
+      expect(
+        nextAutoplayIndex(
+          currentIndex: 4,
+          episodes: eps,
+          fillerEps: {2, 3},
+          autoSkipFiller: true,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns immediate next when auto-skip is off', () {
+      expect(
+        nextAutoplayIndex(
+          currentIndex: 0,
+          episodes: eps,
+          fillerEps: {2, 3},
+          autoSkipFiller: false,
+        ),
+        1,
+      );
+    });
+
+    test('returns immediate next when filler set is empty', () {
+      expect(
+        nextAutoplayIndex(
+          currentIndex: 0,
+          episodes: eps,
+          fillerEps: const {},
+          autoSkipFiller: true,
+        ),
+        1,
+      );
+    });
+
+    test('skips consecutive fillers', () {
+      expect(
+        nextAutoplayIndex(
+          currentIndex: 0,
+          episodes: eps,
+          fillerEps: {2, 3},
+          autoSkipFiller: true,
+        ),
+        3, // index of ep 4
+      );
+    });
+
+    test('falls back to immediate next when rest of list is filler', () {
+      expect(
+        nextAutoplayIndex(
+          currentIndex: 0,
+          episodes: eps,
+          fillerEps: {2, 3, 4, 5},
+          autoSkipFiller: true,
+        ),
+        1,
+      );
+    });
+
+    test('does not skip a non-filler immediate next', () {
+      expect(
+        nextAutoplayIndex(
+          currentIndex: 0,
+          episodes: eps,
+          fillerEps: {3, 4},
+          autoSkipFiller: true,
+        ),
+        1,
+      );
+    });
+  });
+}

--- a/test/features/detail/detail_screen_tv_test.dart
+++ b/test/features/detail/detail_screen_tv_test.dart
@@ -19,6 +19,7 @@ import 'package:watch_app/core/models/media_item.dart';
 import 'package:watch_app/core/models/media_extras.dart';
 import 'package:watch_app/core/models/provider_info.dart';
 import 'package:watch_app/core/models/watch_status.dart';
+import 'package:watch_app/core/playback/filler_service.dart';
 import 'package:watch_app/core/playback/list_status_store.dart';
 import 'package:watch_app/core/playback/my_list.dart';
 import 'package:watch_app/core/playback/resume_store.dart';
@@ -706,6 +707,56 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pumpAndSettle();
       expect(tester.binding.focusManager.primaryFocus, same(playFocus));
+    },
+  );
+
+  testWidgets(
+    'DetailScreenTv shows FILLER badge for Jikan-marked episode numbers',
+    (tester) async {
+      FillerService.instance.debugSeedCache(21, {2});
+      addTearDown(FillerService.instance.debugClearCache);
+
+      const detail = MediaDetail(
+        id: 'filler-show',
+        title: 'Filler Anime',
+        url: 'http://test/filler',
+        type: ProviderType.anime,
+        sourceId: 'test',
+        malId: 21,
+        episodes: [
+          Episode(id: 'e1', title: 'Canon', url: '/e1', number: 1),
+          Episode(id: 'e2', title: 'Filler Ep', url: '/e2', number: 2),
+          Episode(id: 'e3', title: 'Canon Again', url: '/e3', number: 3),
+        ],
+      );
+      const item = MediaItem(
+        id: 'filler-show',
+        title: 'Filler Anime',
+        url: 'http://test/filler',
+        type: ProviderType.anime,
+        sourceId: 'test',
+        malId: 21,
+      );
+
+      await cubit.close();
+      cubit = DetailCubit(
+        repo: _StubSourceRepository(detail),
+        url: item.url,
+        sourceId: item.sourceId,
+        prefs: _FakeTitlePrefs(),
+      );
+      await cubit.load();
+
+      await tester.pumpWidget(
+        BlocProvider<DetailCubit>.value(
+          value: cubit,
+          child: MaterialApp(home: DetailScreenTv(item: item)),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(); // let _ensureFiller setState land
+
+      expect(find.text('FILLER'), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
## Summary
- Bring mobile filler parity to TV: Jikan `FILLER` badges on the TV detail list, Flutter Exo player, and native `TvPlayerActivity`
- Shared `nextAutoplayIndex` helper so phone and TV skip consecutive fillers the same way (with the never-strand fallback)
- When **Auto-skip filler** is on, both autoplay and the Next button jump past fillers; picking an episode from the list still plays it
- Updated wording in Playback Settings to match that behavior

Closes #38

## Screenshots
### Settings toggle: 
<img width="3192" height="650" alt="CleanShot 2026-08-20 at 23 14 13@2x" src="https://github.com/user-attachments/assets/183db898-d061-480b-b0eb-555276d6d363" />


### Filler badge on Episode list: 
<img width="3228" height="1814" alt="CleanShot 2026-08-20 at 23 13 44@2x" src="https://github.com/user-attachments/assets/a15bfc29-a78a-4e14-ba3b-1085073fd7e4" />

### Filler mark on In-player episode list:
<img width="3236" height="1804" alt="CleanShot 2026-08-20 at 23 13 29@2x" src="https://github.com/user-attachments/assets/38e8998b-6b87-4095-bdb6-5a683a9389f2" />
