### PR TITLE
TV: touch to show controls, scrub, and single-tap player pills

### DIFF
--- a/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
@@ -7,6 +7,8 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.SoundEffectConstants
 import android.view.View
 import android.view.WindowManager
 import android.widget.ImageView
@@ -31,6 +33,7 @@ import androidx.media3.exoplayer.drm.LocalMediaDrmCallback
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.ui.CaptionStyleCompat
 import androidx.media3.ui.DefaultTimeBar
+import androidx.media3.ui.TimeBar
 import androidx.media3.ui.PlayerView
 import androidx.media3.ui.SubtitleView
 import io.flutter.plugin.common.MethodChannel
@@ -179,6 +182,8 @@ class TvPlayerActivity : Activity() {
     private var controlsVisible = false
     private var focusZone = 0 // 0 = none (OK=play/pause, ◀▶=seek), 1 = top actions, 2 = bottom
     private val rowFocused get() = focusZone != 0
+    /** True while the user is dragging the time bar — blocks auto-hide + progress fight. */
+    private var scrubbing = false
     private var speedEngaged = false
     private var menuOpen = false
     private var menuOpener: View? = null // the row button that opened the panel
@@ -1092,16 +1097,20 @@ class TvPlayerActivity : Activity() {
             textSize = 16.5f
             if (selected) setTypeface(typeface, android.graphics.Typeface.BOLD)
             isFocusable = true
-            isFocusableInTouchMode = true
             setPadding(dp(16), dp(11), dp(16), dp(11))
             background = pillBg(0x00000000)
-            setOnClickListener { lastFocusLabel = label; onSelect(); closeMenu() }
             onFocusChangeListener = View.OnFocusChangeListener { v, has ->
                 v.background = pillBg(if (has) accent else 0x00000000)
                 (v as TextView).setTextColor(
                     if (has) android.graphics.Color.WHITE
                     else if (selected) android.graphics.Color.WHITE else 0xFFB6B6C0.toInt()
                 )
+            }
+            // Single-tap on touchscreens: highlight + select (not focus-then-click).
+            bindSingleTapActivate {
+                lastFocusLabel = label
+                onSelect()
+                closeMenu()
             }
         }
         if (selected && firstSelectedRow == null) firstSelectedRow = row
@@ -1160,35 +1169,63 @@ class TvPlayerActivity : Activity() {
         // Accent-tinted, clean loading spinner (premium, not the grey default).
         (loading as? android.widget.ProgressBar)?.indeterminateTintList =
             android.content.res.ColorStateList.valueOf(accent)
-        // The seek bar is display-only on TV (◀▶ keys drive seeking), so it must
-        // never steal focus from the button row.
+        // Not D-pad focusable (◀▶ keys still seek) but touch-scrubbable below.
         timeBar.isFocusable = false
+        timeBar.addListener(object : TimeBar.OnScrubListener {
+            override fun onScrubStart(bar: TimeBar, position: Long) {
+                scrubbing = true
+                seekTarget = -1L
+                handler.removeCallbacks(commitSeek)
+                cancelAutoHide()
+                showControls()
+                positionText.text = fmt(position)
+            }
+
+            override fun onScrubMove(bar: TimeBar, position: Long) {
+                positionText.text = fmt(position)
+            }
+
+            override fun onScrubStop(bar: TimeBar, position: Long, canceled: Boolean) {
+                scrubbing = false
+                if (!canceled) {
+                    seekTarget = -1L
+                    player?.seekTo(position)
+                    reportTiming(positionMs = position)
+                }
+                bumpControls()
+            }
+        })
 
         for (b in listOf(btnEpisodes, btnQuality, btnSources, btnAudioSubs, btnNext, btnMegaskip)) {
-            b.isClickable = true
             // Focusable even in touch mode so requestFocus() works on emulators
             // (real TVs are always in D-pad/non-touch mode anyway).
-            b.isFocusableInTouchMode = true
             applyPillFocus(b, false)
             b.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus ->
                 applyPillFocus(v as TextView, hasFocus)
-                if (hasFocus) cancelAutoHide()
+                if (hasFocus) {
+                    // Keep zone in sync for touch focus (D-pad uses enterZone).
+                    focusZone = when (v.id) {
+                        R.id.btn_quality, R.id.btn_sources, R.id.btn_audio_subs -> 1
+                        else -> 2 // episodes / next / megaskip bottom row
+                    }
+                    cancelAutoHide()
+                }
             }
         }
-        // Phase-2 wiring lands in later tasks; for now the buttons are focusable
-        // and highlight, so the layout + D-pad model can be verified end to end.
-        btnEpisodes.setOnClickListener { openEpisodes() }
-        btnQuality.setOnClickListener { openQualityMenu() }
-        btnSources.setOnClickListener { openSourcesMenu() }
-        btnAudioSubs.setOnClickListener { openAvMenu() }
-        btnNext.setOnClickListener { loadEpisode(nextAutoplayIndex()) }
-        btnMegaskip.setOnClickListener { seekBy(megaSkipSecs * 1000L) }
+        // Single-tap on touchscreens: highlight + fire (focusableInTouchMode alone
+        // would eat the first tap for focus only). Next uses nextAutoplayIndex so
+        // autoSkipFiller applies to the button as well as binge autoplay.
+        btnEpisodes.bindSingleTapActivate { openEpisodes() }
+        btnQuality.bindSingleTapActivate { openQualityMenu() }
+        btnSources.bindSingleTapActivate { openSourcesMenu() }
+        btnAudioSubs.bindSingleTapActivate { openAvMenu() }
+        btnNext.bindSingleTapActivate { loadEpisode(nextAutoplayIndex()) }
+        btnMegaskip.bindSingleTapActivate { seekBy(megaSkipSecs * 1000L) }
 
-        skipButton.isFocusableInTouchMode = true
         applyPillFocus(skipButton, false)
         skipButton.onFocusChangeListener =
             View.OnFocusChangeListener { v, has -> applyPillFocus(v as TextView, has) }
-        skipButton.setOnClickListener {
+        skipButton.bindSingleTapActivate {
             if (activeSkipEnd > 0) {
                 val end = activeSkipEnd
                 player?.seekTo(end)
@@ -1196,6 +1233,44 @@ class TvPlayerActivity : Activity() {
                 reportTiming(positionMs = end)
             }
             hideSkip()
+        }
+
+        // Touchscreen TVs: tap empty video / chrome to show or hide controls.
+        // Wired on playerView (controls GONE) and controls (controls VISIBLE) so
+        // we never attach a click listener to the focusable root — that would
+        // collide with D-pad OK play/pause.
+        playerView.setOnClickListener { toggleControlsFromTouch() }
+        controls.isFocusable = false
+        controls.setOnClickListener { toggleControlsFromTouch() }
+    }
+
+    /**
+     * focusableInTouchMode + OnClickListener normally needs two taps on a
+     * touchscreen (1st focuses, 2nd clicks). Consume the touch and on UP both
+     * request focus (pill highlight) and performClick so one tap does both.
+     * D-pad OK still goes through the normal click / key path.
+     */
+    private fun View.bindSingleTapActivate(onActivate: () -> Unit) {
+        isClickable = true
+        isFocusable = true
+        isFocusableInTouchMode = true
+        setOnClickListener { onActivate() }
+        setOnTouchListener { v, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> true
+                MotionEvent.ACTION_CANCEL -> true
+                MotionEvent.ACTION_UP -> {
+                    if (event.x >= 0f && event.x < v.width &&
+                        event.y >= 0f && event.y < v.height
+                    ) {
+                        v.requestFocus()
+                        v.playSoundEffect(SoundEffectConstants.CLICK)
+                        v.performClick()
+                    }
+                    true
+                }
+                else -> false
+            }
         }
     }
 
@@ -1219,7 +1294,7 @@ class TvPlayerActivity : Activity() {
     }
 
     private fun hideControls() {
-        if (rowFocused) return // never yank the row out from under the user
+        if (rowFocused || scrubbing) return // never yank chrome mid-row / mid-scrub
         controls.visibility = View.GONE
         controlsVisible = false
     }
@@ -1231,7 +1306,26 @@ class TvPlayerActivity : Activity() {
         if (menuOpen) return
         showControls()
         handler.removeCallbacks(hideRunnable)
-        if (!rowFocused && player?.isPlaying == true) handler.postDelayed(hideRunnable, AUTO_HIDE_MS)
+        if (!rowFocused && !scrubbing && player?.isPlaying == true) {
+            handler.postDelayed(hideRunnable, AUTO_HIDE_MS)
+        }
+    }
+
+    /** Touch on empty video/chrome:
+     *  - side menu open → dismiss the menu
+     *  - controls visible → play/pause (same as remote OK; shows center glyph)
+     *  - controls hidden → show controls
+     *  Menu rows / control pills still consume their own taps. */
+    private fun toggleControlsFromTouch() {
+        if (menuOpen) {
+            closeMenu()
+            return
+        }
+        if (controls.visibility == View.VISIBLE) {
+            togglePlayPause()
+        } else {
+            bumpControls()
+        }
     }
 
     private fun cancelAutoHide() = handler.removeCallbacks(hideRunnable)
@@ -1249,9 +1343,12 @@ class TvPlayerActivity : Activity() {
         // to the old position between presses and the commit.
         val pos = if (seekTarget >= 0) seekTarget else p.currentPosition.coerceAtLeast(0)
         timeBar.setDuration(dur)
-        timeBar.setPosition(pos)
+        // Don't fight the finger — DefaultTimeBar owns position while scrubbing.
+        if (!scrubbing) {
+            timeBar.setPosition(pos)
+            positionText.text = fmt(pos)
+        }
         timeBar.setBufferedPosition(p.bufferedPosition.coerceAtLeast(0))
-        positionText.text = fmt(pos)
         durationText.text = fmt(dur)
     }
 

--- a/lib/features/player/tv_exo_player_screen.dart
+++ b/lib/features/player/tv_exo_player_screen.dart
@@ -160,6 +160,9 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   Timer? _upNextTimer;
   bool _controlsVisible = true; // bottom controls; auto-hide after inactivity
   Timer? _controlsHideTimer;
+  /// Touch-dragging the seek slider — keep chrome up and drive the thumb locally.
+  bool _scrubbing = false;
+  int? _scrubMs;
   bool _holdingSpeed = false; // D-pad RIGHT held → temporary 2× (YouTube-style)
 
   /// Filler episode NUMBERS from Jikan (same as phone player). Empty until
@@ -251,11 +254,34 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
           !_menuOpen &&
           !_episodesOpen &&
           !_controlRowFocused &&
+          !_scrubbing &&
           _searchResults == null &&
           _upNextCountdown == null) {
         setState(() => _controlsVisible = false);
       }
     });
+  }
+
+  /// Touch on empty video/chrome:
+  /// - side menu open → dismiss the menu
+  /// - controls visible → play/pause (same as remote OK)
+  /// - controls hidden → show controls
+  void _toggleControlsFromTouch() {
+    if (_menuOpen) {
+      _closeMenu();
+      return;
+    }
+    if (_searchResults != null) {
+      setState(() => _searchResults = null);
+      _rootFocus.requestFocus();
+      return;
+    }
+    if (_episodesOpen || _upNextCountdown != null) return;
+    if (_controlsVisible) {
+      _togglePlay();
+    } else {
+      _bumpControls();
+    }
   }
 
   void _onPlayingChanged() {
@@ -1556,6 +1582,15 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
                   },
                 ),
               ),
+              // Touchscreen: tap empty video to show/hide chrome. Sits above the
+              // PlatformView and under the controls overlay so visible pills still
+              // receive taps.
+              Positioned.fill(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: _toggleControlsFromTouch,
+                ),
+              ),
               if (_error != null)
                 Center(
                   child: Text(
@@ -1760,143 +1795,216 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
         (icon: Icons.skip_next_rounded, label: 'Next Episode', onTap: _next),
     ];
     return Positioned.fill(
-      child: Column(
+      child: Stack(
         children: [
-          // ── Top scrim + title / episode ────────────────────────────────────
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.fromLTRB(48, 36, 48, 56),
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [Colors.black87, Colors.transparent],
-              ),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  widget.showTitle ?? '',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 26,
-                    fontWeight: FontWeight.w700,
+          Column(
+            children: [
+              // ── Top scrim + title / episode ────────────────────────────────────
+              GestureDetector(
+                onTap: _toggleControlsFromTouch,
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.fromLTRB(48, 36, 48, 56),
+                  decoration: const BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [Colors.black87, Colors.transparent],
+                    ),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        widget.showTitle ?? '',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 26,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      if (epLabel != null) ...[
+                        const SizedBox(height: 4),
+                        ValueListenableBuilder<Set<int>>(
+                          valueListenable: _fillerEps,
+                          builder: (context, fillers, _) {
+                            final n = ep?.number?.toInt();
+                            final isFiller = n != null && fillers.contains(n);
+                            return Row(
+                              children: [
+                                Text(
+                                  epLabel,
+                                  style: TextStyle(
+                                    color: Colors.white.withValues(alpha: 0.7),
+                                    fontSize: 16,
+                                  ),
+                                ),
+                                if (isFiller) ...[
+                                  const SizedBox(width: 8),
+                                  const TagBadge(text: 'FILLER'),
+                                ],
+                              ],
+                            );
+                          },
+                        ),
+                      ],
+                    ],
                   ),
                 ),
-                if (epLabel != null) ...[
-                  const SizedBox(height: 4),
-                  ValueListenableBuilder<Set<int>>(
-                    valueListenable: _fillerEps,
-                    builder: (context, fillers, _) {
-                      final n = ep?.number?.toInt();
-                      final isFiller = n != null && fillers.contains(n);
-                      return Row(
-                        children: [
-                          Text(
-                            epLabel,
-                            style: TextStyle(
-                              color: Colors.white.withValues(alpha: 0.7),
-                              fontSize: 16,
-                            ),
-                          ),
-                          if (isFiller) ...[
-                            const SizedBox(width: 8),
-                            const TagBadge(text: 'FILLER'),
-                          ],
-                        ],
-                      );
-                    },
-                  ),
-                ],
-              ],
-            ),
-          ),
-          const Spacer(),
-          // ── Bottom scrim + scrubber + button row ───────────────────────────
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.fromLTRB(48, 44, 48, 34),
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.bottomCenter,
-                end: Alignment.topCenter,
-                colors: [Colors.black, Colors.transparent],
               ),
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ValueListenableBuilder<int>(
-                  valueListenable: c.position,
-                  builder: (_, pos, _) => ValueListenableBuilder<int>(
-                    valueListenable: c.duration,
-                    builder: (_, dur, _) {
-                      final frac = dur > 0 ? (pos / dur).clamp(0.0, 1.0) : 0.0;
-                      return Row(
-                        children: [
-                          Text(
-                            _fmt(pos),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          const SizedBox(width: 16),
-                          Expanded(
-                            child: ClipRRect(
-                              borderRadius: BorderRadius.circular(4),
-                              // Read-only label+value — NOT slider:true, so
-                              // this stays a display node, not a focusable
-                              // seek control.
-                              child: Semantics(
-                                label: 'Seek bar',
-                                value: '${_fmt(pos)} of ${_fmt(dur)}',
-                                child: LinearProgressIndicator(
-                                  value: frac,
-                                  minHeight: 6,
-                                  backgroundColor: Colors.white24,
-                                  valueColor: AlwaysStoppedAnimation(
-                                    AppColors.accent,
+              // Empty mid-video: tap play/pauses while chrome is up.
+              Expanded(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: _toggleControlsFromTouch,
+                ),
+              ),
+              // ── Bottom scrim + scrubber + button row ───────────────────────────
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.fromLTRB(48, 44, 48, 34),
+                decoration: const BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.bottomCenter,
+                    end: Alignment.topCenter,
+                    colors: [Colors.black, Colors.transparent],
+                  ),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ValueListenableBuilder<int>(
+                      valueListenable: c.position,
+                      builder: (_, pos, _) => ValueListenableBuilder<int>(
+                        valueListenable: c.duration,
+                        builder: (_, dur, _) {
+                          final displayPos = _scrubMs ?? pos;
+                          final frac = dur > 0
+                              ? (displayPos / dur).clamp(0.0, 1.0)
+                              : 0.0;
+                          return Row(
+                            children: [
+                              Text(
+                                _fmt(displayPos),
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                // ExcludeFocus: D-pad must not land on the
+                                // slider (◀▶ still seek from the root).
+                                child: ExcludeFocus(
+                                  child: SliderTheme(
+                                    data: SliderTheme.of(context).copyWith(
+                                      trackHeight: 6,
+                                      thumbShape: const RoundSliderThumbShape(
+                                        enabledThumbRadius: 8,
+                                      ),
+                                      overlayShape:
+                                          const RoundSliderOverlayShape(
+                                            overlayRadius: 14,
+                                          ),
+                                      activeTrackColor: AppColors.accent,
+                                      inactiveTrackColor: Colors.white24,
+                                      thumbColor: AppColors.accent,
+                                      overlayColor: AppColors.accent
+                                          .withValues(alpha: 0.25),
+                                    ),
+                                    child: Slider(
+                                      value: frac.toDouble(),
+                                      onChangeStart: dur > 0
+                                          ? (_) {
+                                              _controlsHideTimer?.cancel();
+                                              setState(() {
+                                                _scrubbing = true;
+                                                _scrubMs = displayPos;
+                                              });
+                                            }
+                                          : null,
+                                      onChanged: dur > 0
+                                          ? (v) {
+                                              setState(() {
+                                                _scrubMs = (v * dur).round();
+                                              });
+                                            }
+                                          : null,
+                                      onChangeEnd: dur > 0
+                                          ? (v) {
+                                              final target = (v * dur).round();
+                                              c.seek(target);
+                                              setState(() {
+                                                _scrubbing = false;
+                                                _scrubMs = null;
+                                              });
+                                              _bumpControls();
+                                            }
+                                          : null,
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                          ),
-                          const SizedBox(width: 16),
-                          Text(
-                            _fmt(dur),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ],
-                      );
-                    },
-                  ),
-                ),
-                const SizedBox(height: 18),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    for (var i = 0; i < buttons.length; i++)
-                      _controlRowButton(
-                        i,
-                        buttons.length,
-                        buttons[i].icon,
-                        buttons[i].label,
-                        buttons[i].onTap,
+                              const SizedBox(width: 8),
+                              Text(
+                                _fmt(dur),
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          );
+                        },
                       ),
+                    ),
+                    const SizedBox(height: 18),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        for (var i = 0; i < buttons.length; i++)
+                          _controlRowButton(
+                            i,
+                            buttons.length,
+                            buttons[i].icon,
+                            buttons[i].label,
+                            buttons[i].onTap,
+                          ),
+                      ],
+                    ),
                   ],
                 ),
-              ],
-            ),
+              ),
+            ],
+          ),
+          // Center play glyph while paused (matches native remote OK feedback).
+          ValueListenableBuilder<bool>(
+            valueListenable: c.playing,
+            builder: (_, playing, _) {
+              if (playing) return const SizedBox.shrink();
+              return IgnorePointer(
+                child: Center(
+                  child: Container(
+                    width: 86,
+                    height: 86,
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.55),
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(
+                      Icons.play_arrow_rounded,
+                      color: Colors.white,
+                      size: 48,
+                    ),
+                  ),
+                ),
+              );
+            },
           ),
         ],
       ),
@@ -1950,37 +2058,44 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
         child: Builder(
           builder: (context) {
             final focused = Focus.of(context).hasFocus;
-            return AnimatedContainer(
-              duration: const Duration(milliseconds: 120),
-              margin: const EdgeInsets.symmetric(horizontal: 6),
-              padding: const EdgeInsets.symmetric(
-                horizontal: 18,
-                vertical: 11,
-              ),
-              decoration: BoxDecoration(
-                color: focused
-                    ? AppColors.accent
-                    : Colors.white.withValues(alpha: 0.14),
-                borderRadius: BorderRadius.circular(24),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(icon, size: 20, color: Colors.white),
-                  const SizedBox(width: 8),
-                  // The Semantics above already announces the label —
-                  // exclude this sibling so TalkBack doesn't say it twice.
-                  ExcludeSemantics(
-                    child: Text(
-                      label,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
+            return GestureDetector(
+              onTap: () {
+                setState(() => _controlRowFocused = true);
+                _rowFocusNodes[index].requestFocus();
+                onTap();
+              },
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 120),
+                margin: const EdgeInsets.symmetric(horizontal: 6),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 18,
+                  vertical: 11,
+                ),
+                decoration: BoxDecoration(
+                  color: focused
+                      ? AppColors.accent
+                      : Colors.white.withValues(alpha: 0.14),
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(icon, size: 20, color: Colors.white),
+                    const SizedBox(width: 8),
+                    // The Semantics above already announces the label —
+                    // exclude this sibling so TalkBack doesn't say it twice.
+                    ExcludeSemantics(
+                      child: Text(
+                        label,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             );
           },
@@ -2104,7 +2219,10 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
         builder: (context) {
           final focused = Focus.of(context).hasFocus;
           return GestureDetector(
-            onTap: onTap,
+            onTap: () {
+              Focus.of(context).requestFocus();
+              onTap();
+            },
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
               decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- Fixes touchscreen TV playback so tapping the video shows controls; with controls up, tap play/pauses (center play glyph); with a side menu open, tap dismisses the menu ([#40](https://github.com/Spyou/Zangetsu/issues/40)).
- Enables touch scrubbing on the seek bar and keeps chrome visible while dragging (no auto-hide mid-scrub).
- Makes control pills / menu rows activate on a single tap (highlight + fire), instead of focus-then-click.

Applies to the native TV player and the Flutter Exo fallback.

## How to Verify
- [ ] On a touchscreen TV / emulator: controls hidden → tap video → controls appear
- [ ] Controls visible → tap empty video → play/pause; pause shows center play glyph (same as remote OK)
- [ ] Open Episodes / Quality / Sources / Audio & Subs → tap video outside menu → menu dismisses
- [ ] Drag the seek bar → position updates and seek commits on release; controls stay up while dragging
- [ ] Single-tap Episodes / Quality / Sources / Audio & Subs / Next / MegaSkip / Skip (and menu rows) → highlights and fires without a second tap
- [ ] D-pad OK still play/pauses; ◀▶ still seek; remote focus navigation unchanged

Closes #40