### PR TITLE
fix(tv): show connection lists on My List (#41)

### DIFF
--- a/lib/core/ui/tracker_entry_sheet.dart
+++ b/lib/core/ui/tracker_entry_sheet.dart
@@ -1,12 +1,16 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
+import '../app_mode.dart';
+import '../di/injector.dart';
 import '../models/media_item.dart';
 import '../anilist/anilist_service.dart';
 import '../models/provider_info.dart';
 import '../models/watch_status.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_text.dart';
+import '../tv/tv_focusable.dart';
+import '../tv/tv_list_focusable.dart';
 import 'anilist_custom_lists_sheet.dart';
 import '../tracker/tracker.dart';
 
@@ -142,72 +146,87 @@ class _TrackerEntrySheetState extends State<_TrackerEntrySheet> {
     if (mounted) Navigator.pop(context);
   }
 
+  bool get _isTv =>
+      sl.isRegistered<AppMode>() && sl<AppMode>().isTv;
+
   @override
   Widget build(BuildContext context) {
+    // Cap height + scroll so status chips / steppers / actions don't overflow
+    // the bottom sheet on TV (extra TvFocusable chrome) or short phone screens.
     return SafeArea(
       child: Padding(
         padding: EdgeInsets.only(
           bottom: MediaQuery.viewInsetsOf(context).bottom,
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const SizedBox(height: 10),
-            Center(
-              child: Container(
-                width: 36,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: AppColors.hairline,
-                  borderRadius: BorderRadius.circular(2),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.sizeOf(context).height * 0.85,
+          ),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: 10),
+                Center(
+                  child: Container(
+                    width: 36,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: AppColors.hairline,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
                 ),
-              ),
+                _header(),
+                const Divider(
+                    height: 1, thickness: 1, color: AppColors.hairline),
+                const SizedBox(height: 18),
+                _statusChips(),
+                _customListsRow(context),
+                const SizedBox(height: 20),
+                _stepperRow(
+                  _reading ? 'Chapters' : 'Episodes',
+                  _progress.toString(),
+                  onMinus: _progress > 0
+                      ? () => setState(() => _progress--)
+                      : null,
+                  onPlus: () => setState(() => _progress++),
+                ),
+                const SizedBox(height: 16),
+                _stepperRow(
+                  'Score',
+                  _score == 0 ? 'Not rated' : '$_score / 10',
+                  onMinus:
+                      _score > 0 ? () => setState(() => _score--) : null,
+                  onPlus:
+                      _score < 10 ? () => setState(() => _score++) : null,
+                ),
+                const SizedBox(height: 24),
+                _applyButton(),
+                const SizedBox(height: 6),
+                if (widget.onFind != null)
+                  _actionRow(
+                    Icons.search_rounded,
+                    'Find to watch',
+                    color: AppColors.textPrimary,
+                    onTap: _busy
+                        ? null
+                        : () {
+                            Navigator.pop(context);
+                            widget.onFind!.call();
+                          },
+                  ),
+                _actionRow(
+                  Icons.delete_outline_rounded,
+                  'Remove from ${widget.tracker.displayName}',
+                  color: AppColors.accent,
+                  onTap: _busy ? null : _remove,
+                ),
+                const SizedBox(height: 10),
+              ],
             ),
-            _header(),
-            const Divider(height: 1, thickness: 1, color: AppColors.hairline),
-            const SizedBox(height: 18),
-            _statusChips(),
-            _customListsRow(context),
-            const SizedBox(height: 20),
-            _stepperRow(
-              _reading ? 'Chapters' : 'Episodes',
-              _progress.toString(),
-              onMinus: _progress > 0
-                  ? () => setState(() => _progress--)
-                  : null,
-              onPlus: () => setState(() => _progress++),
-            ),
-            const SizedBox(height: 16),
-            _stepperRow(
-              'Score',
-              _score == 0 ? 'Not rated' : '$_score / 10',
-              onMinus: _score > 0 ? () => setState(() => _score--) : null,
-              onPlus: _score < 10 ? () => setState(() => _score++) : null,
-            ),
-            const SizedBox(height: 24),
-            _applyButton(),
-            const SizedBox(height: 6),
-            if (widget.onFind != null)
-              _actionRow(
-                Icons.search_rounded,
-                'Find to watch',
-                color: AppColors.textPrimary,
-                onTap: _busy
-                    ? null
-                    : () {
-                        Navigator.pop(context);
-                        widget.onFind!.call();
-                      },
-              ),
-            _actionRow(
-              Icons.delete_outline_rounded,
-              'Remove from ${widget.tracker.displayName}',
-              color: AppColors.accent,
-              onTap: _busy ? null : _remove,
-            ),
-            const SizedBox(height: 10),
-          ],
+          ),
         ),
       ),
     );
@@ -215,7 +234,7 @@ class _TrackerEntrySheetState extends State<_TrackerEntrySheet> {
 
   Widget _actionRow(IconData icon, String label,
       {required Color color, required VoidCallback? onTap}) {
-    return InkWell(
+    final row = InkWell(
       onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
@@ -226,6 +245,29 @@ class _TrackerEntrySheetState extends State<_TrackerEntrySheet> {
             Text(label, style: AppText.body.copyWith(color: color)),
           ],
         ),
+      ),
+    );
+    return _tvRow(
+      onTap: onTap ?? () {},
+      child: row,
+    );
+  }
+
+  /// Phone keeps InkWell/ListTile as-is. TV wraps so D-pad OK can activate
+  /// after a held-OK on a My List tracker poster.
+  Widget _tvRow({
+    required Widget child,
+    required VoidCallback onTap,
+    bool autofocus = false,
+  }) {
+    if (!_isTv) return child;
+    return TvListFocusable(
+      autofocus: autofocus,
+      onTap: onTap,
+      child: Focus(
+        canRequestFocus: false,
+        descendantsAreFocusable: false,
+        child: child,
       ),
     );
   }
@@ -283,33 +325,38 @@ class _TrackerEntrySheetState extends State<_TrackerEntrySheet> {
     final service = widget.tracker;
     if (service is! AniListService) return const SizedBox.shrink();
     final n = widget.customLists.length;
-    return ListTile(
-      leading: const Icon(Icons.playlist_add_rounded,
-          color: AppColors.textSecondary),
-      title: const Text('Custom lists'),
-      subtitle: Text(
-        n == 0 ? 'Not in any' : widget.customLists.join(', '),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: AppText.caption,
+    Future<void> openLists() async {
+      // Grab the navigator's own context BEFORE popping. Using `context`
+      // after the pop passes a dead one to the picker, whose first
+      // `context.mounted` check then bails — the sheet closed and nothing
+      // opened, which looked exactly like the row doing nothing.
+      final rootContext = Navigator.of(context, rootNavigator: true).context;
+      Navigator.pop(context);
+      await showAniListCustomListsSheet(
+        rootContext,
+        service,
+        widget.item,
+        widget.customLists,
+      );
+      widget.onChanged?.call();
+    }
+
+    return _tvRow(
+      onTap: openLists,
+      child: ListTile(
+        leading: const Icon(Icons.playlist_add_rounded,
+            color: AppColors.textSecondary),
+        title: const Text('Custom lists'),
+        subtitle: Text(
+          n == 0 ? 'Not in any' : widget.customLists.join(', '),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppText.caption,
+        ),
+        trailing: const Icon(Icons.chevron_right_rounded,
+            color: AppColors.textSecondary, size: 20),
+        onTap: openLists,
       ),
-      trailing: const Icon(Icons.chevron_right_rounded,
-          color: AppColors.textSecondary, size: 20),
-      onTap: () async {
-        // Grab the navigator's own context BEFORE popping. Using `context`
-        // after the pop passes a dead one to the picker, whose first
-        // `context.mounted` check then bails — the sheet closed and nothing
-        // opened, which looked exactly like the row doing nothing.
-        final rootContext = Navigator.of(context, rootNavigator: true).context;
-        Navigator.pop(context);
-        await showAniListCustomListsSheet(
-          rootContext,
-          service,
-          widget.item,
-          widget.customLists,
-        );
-        widget.onChanged?.call();
-      },
     );
   }
 
@@ -329,30 +376,7 @@ class _TrackerEntrySheetState extends State<_TrackerEntrySheet> {
             spacing: 8,
             runSpacing: 8,
             children: [
-              for (final s in WatchStatus.values)
-                GestureDetector(
-                  onTap: () => setState(() => _status = s),
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 14, vertical: 8),
-                    decoration: BoxDecoration(
-                      color: _status == s
-                          ? AppColors.accent
-                          : AppColors.surface2,
-                      borderRadius: BorderRadius.circular(18),
-                    ),
-                    child: Text(
-                      s.shortLabel,
-                      style: AppText.body.copyWith(
-                        fontSize: 13.5,
-                        fontWeight: FontWeight.w600,
-                        color: _status == s
-                            ? Colors.white
-                            : AppColors.textSecondary,
-                      ),
-                    ),
-                  ),
-                ),
+              for (final s in WatchStatus.values) _statusChip(s),
             ],
           ),
         ],
@@ -360,23 +384,68 @@ class _TrackerEntrySheetState extends State<_TrackerEntrySheet> {
     );
   }
 
+  Widget _statusChip(WatchStatus s) {
+    final selected = _status == s;
+    final chip = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: selected ? AppColors.accent : AppColors.surface2,
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Text(
+        s.shortLabel,
+        style: AppText.body.copyWith(
+          fontSize: 13.5,
+          fontWeight: FontWeight.w600,
+          color: selected ? Colors.white : AppColors.textSecondary,
+        ),
+      ),
+    );
+    if (_isTv) {
+      // Accent-selected chips need a white outline (float/box), not the
+      // accent row wash — same rationale as [TvActionChip].
+      return TvFocusable(
+        variant: selected ? TvFocusVariant.float : TvFocusVariant.box,
+        scale: 1.0,
+        borderRadius: 18,
+        onTap: () => setState(() => _status = s),
+        child: chip,
+      );
+    }
+    return GestureDetector(
+      onTap: () => setState(() => _status = s),
+      child: chip,
+    );
+  }
+
   Widget _stepperRow(String label, String value,
       {VoidCallback? onMinus, VoidCallback? onPlus}) {
-    Widget btn(IconData icon, VoidCallback? onTap) => GestureDetector(
-          onTap: onTap,
-          child: Container(
-            width: 34,
-            height: 34,
-            decoration: BoxDecoration(
-              color: AppColors.surface2,
-              shape: BoxShape.circle,
-            ),
-            child: Icon(icon,
-                size: 18,
-                color:
-                    onTap == null ? AppColors.textTertiary : AppColors.accent),
-          ),
-        );
+    Widget btn(IconData icon, VoidCallback? onTap, String semantic) {
+      final face = Container(
+        width: 34,
+        height: 34,
+        decoration: BoxDecoration(
+          color: AppColors.surface2,
+          shape: BoxShape.circle,
+        ),
+        child: Icon(icon,
+            size: 18,
+            color: onTap == null ? AppColors.textTertiary : AppColors.accent),
+      );
+      if (!_isTv) {
+        return GestureDetector(onTap: onTap, child: face);
+      }
+      if (onTap == null) return face;
+      return TvFocusable(
+        variant: TvFocusVariant.box,
+        scale: 1.12,
+        borderRadius: 17,
+        semanticLabel: semantic,
+        onTap: onTap,
+        child: face,
+      );
+    }
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
       child: Row(
@@ -384,7 +453,7 @@ class _TrackerEntrySheetState extends State<_TrackerEntrySheet> {
           Text(label,
               style: AppText.body.copyWith(color: AppColors.textPrimary)),
           const Spacer(),
-          btn(Icons.remove_rounded, onMinus),
+          btn(Icons.remove_rounded, onMinus, 'Decrease $label'),
           SizedBox(
             width: 92,
             child: Text(value,
@@ -393,37 +462,55 @@ class _TrackerEntrySheetState extends State<_TrackerEntrySheet> {
                     color: AppColors.textPrimary,
                     fontWeight: FontWeight.w700)),
           ),
-          btn(Icons.add_rounded, onPlus),
+          btn(Icons.add_rounded, onPlus, 'Increase $label'),
         ],
       ),
     );
   }
 
   Widget _applyButton() {
+    // Plain accent face (not FilledButton) so TV focus chrome isn't fighting
+    // Material's own focus node. Accent fill → white outline ([TvFocusVariant.box]),
+    // never [TvListFocusable]/row — the red wash is invisible on a red button.
+    final face = Container(
+      width: double.infinity,
+      height: 48,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: AppColors.accent,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: _busy
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                  strokeWidth: 2, color: Colors.white),
+            )
+          : Text('Apply changes',
+              style: AppText.body.copyWith(
+                  color: Colors.white, fontWeight: FontWeight.w700)),
+    );
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
-      child: SizedBox(
-        width: double.infinity,
-        height: 48,
-        child: FilledButton(
-          style: FilledButton.styleFrom(
-            backgroundColor: AppColors.accent,
-            shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(14)),
-          ),
-          onPressed: _busy ? null : _apply,
-          child: _busy
-              ? const SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CircularProgressIndicator(
-                      strokeWidth: 2, color: Colors.white),
-                )
-              : Text('Apply changes',
-                  style: AppText.body.copyWith(
-                      color: Colors.white, fontWeight: FontWeight.w700)),
-        ),
-      ),
+      child: _isTv
+          ? TvFocusable(
+              autofocus: true,
+              variant: TvFocusVariant.box,
+              scale: 1.03,
+              borderRadius: 14,
+              semanticLabel: 'Apply changes',
+              onTap: _busy ? () {} : _apply,
+              child: face,
+            )
+          : Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: _busy ? null : _apply,
+                borderRadius: BorderRadius.circular(14),
+                child: face,
+              ),
+            ),
     );
   }
 }

--- a/lib/features/home/my_list_screen_tv.dart
+++ b/lib/features/home/my_list_screen_tv.dart
@@ -1,27 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../core/di/injector.dart';
+import '../../core/mode/content_mode_cubit.dart';
 import '../../core/models/media_item.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_text.dart';
+import '../../core/tracker/tracker.dart';
+import '../../core/tracker/tracker_hub.dart';
+import '../../core/tv/tv_focusable.dart';
 import '../../core/tv/tv_poster_tile.dart';
 import '../../core/ui/list_status_sheet.dart';
 import '../../core/ui/states.dart';
+import '../../core/ui/tracker_entry_sheet.dart';
 import '../detail/detail_screen.dart';
 import 'cubit/my_list_cubit.dart';
+import 'cubit/tracker_list_cubit.dart';
+import 'search_screen.dart';
 
-/// TV My List: a full-screen focusable poster grid backed by [MyListCubit].
+/// TV My List: a full-screen focusable poster grid backed by [MyListCubit]
+/// (own list) and [TrackerListCubit] (AniList / MAL / Simkl when connected).
 ///
-/// Reuses the phone's cubit/state and [PosterCard] widget unchanged. Only the
-/// interaction model changes: each card is wrapped in [TvFocusable] so the
-/// D-pad navigates the grid, OK opens the Detail screen, and a held OK opens
-/// the same status/remove sheet as the phone long-press. The rail↔content
-/// focus bridge in [RootShellTv] already handles LEFT-at-edge → rail, so no
-/// additional navigation plumbing is needed.
-///
-/// The phone [MyListScreen] is byte-identical except for the single
-/// `if (sl<AppMode>().isTv) return const MyListScreenTv();` branch added at
-/// the top of [_MyListViewState.build].
+/// Reuses the phone's cubits unchanged. Only the interaction model changes:
+/// each card is wrapped in [TvFocusable] so the D-pad navigates the grid, OK
+/// opens Detail (or Search for tracker stubs), and a held OK opens the same
+/// status/remove sheet as the phone long-press. A chip row switches between
+/// My List and each connected tracker — same sources as the phone segmented
+/// control. The rail↔content focus bridge in [RootShellTv] already handles
+/// LEFT-at-edge → rail.
 class MyListScreenTv extends StatelessWidget {
   const MyListScreenTv({super.key});
 
@@ -29,10 +35,18 @@ class MyListScreenTv extends StatelessWidget {
   /// (matches the see-all grid; 5 rendered them oversized).
   static const int _crossAxisCount = 6;
 
-  Future<void> _openItem(BuildContext context, MediaItem item) async {
+  Future<void> _openOwnItem(BuildContext context, MediaItem item) async {
     final cubit = context.read<MyListCubit>();
     await Navigator.push(context, DetailScreen.route(item));
     cubit.reload();
+  }
+
+  void _openTrackerItem(BuildContext context, MediaItem stub) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => SearchScreen(initialQuery: stub.title),
+      ),
+    );
   }
 
   @override
@@ -40,60 +54,239 @@ class MyListScreenTv extends StatelessWidget {
     return Scaffold(
       backgroundColor: AppColors.bg,
       body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // ── Title header ──────────────────────────────────────────────────
-            Padding(
-              padding: const EdgeInsets.fromLTRB(48, 24, 48, 16),
-              child: Text('My List', style: AppText.largeTitle),
-            ),
-            // ── Poster grid ───────────────────────────────────────────────────
-            Expanded(
-              child: BlocBuilder<MyListCubit, List<MyListEntry>>(
-                builder: (context, entries) {
-                  if (entries.isEmpty) {
-                    return const EmptyState(
-                      icon: Icons.bookmark_outline,
-                      message: 'Titles you add appear here',
-                    );
-                  }
-                  return GridView.builder(
-                    padding: const EdgeInsets.fromLTRB(40, 0, 40, 40),
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: _crossAxisCount,
-                      // Poster art + title below (outline hugs the art).
-                      childAspectRatio: 0.56,
-                      crossAxisSpacing: 18,
-                      mainAxisSpacing: 22,
-                    ),
-                    itemCount: entries.length,
-                    itemBuilder: (context, i) {
-                      final entry = entries[i];
-                      return TvPosterTile(
-                        autofocus: i == 0,
-                        title: entry.item.title,
-                        imageUrl: entry.item.cover,
-                        headers: entry.item.coverHeaders,
-                        onTap: () => _openItem(context, entry.item),
-                        onLongPress: () {
-                          final cubit = context.read<MyListCubit>();
-                          showListStatusSheet(
-                            context,
-                            item: entry.item,
-                            onChanged: cubit.reload,
-                          );
-                        },
-                      );
-                    },
-                  );
-                },
-              ),
-            ),
-          ],
+        child: BlocBuilder<TrackerListCubit, TrackerListState>(
+          builder: (context, tlState) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(48, 24, 48, 16),
+                  child: Text('My List', style: AppText.largeTitle),
+                ),
+                _SourceChips(tlState: tlState),
+                // Gap so poster float rings (scale + outer outline) don't paint
+                // up under the source chips — Column paints the grid AFTER the
+                // chips, so any upward bleed covers the chip focus chrome.
+                const SizedBox(height: 8),
+                Expanded(
+                  child: tlState.isMyList
+                      ? _ownListBody(context)
+                      : _trackerBody(context, tlState),
+                ),
+              ],
+            );
+          },
         ),
       ),
     );
   }
+
+  Widget _ownListBody(BuildContext context) {
+    return BlocBuilder<MyListCubit, List<MyListEntry>>(
+      builder: (context, entries) {
+        if (entries.isEmpty) {
+          return const EmptyState(
+            icon: Icons.bookmark_outline,
+            message: 'Titles you add appear here',
+          );
+        }
+        // Chips take autofocus when present; otherwise first poster.
+        final chipsVisible = _connectedTrackers().isNotEmpty;
+        return _posterGrid(
+          entries: entries,
+          autofocusFirst: !chipsVisible,
+          onTap: (item) => _openOwnItem(context, item),
+          onLongPress: (entry) {
+            final cubit = context.read<MyListCubit>();
+            showListStatusSheet(
+              context,
+              item: entry.item,
+              onChanged: cubit.reload,
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _trackerBody(BuildContext context, TrackerListState tlState) {
+    switch (tlState.status) {
+      case TrackerListStatus.loading:
+        return Center(
+          child: CircularProgressIndicator(color: AppColors.accent),
+        );
+      case TrackerListStatus.error:
+        return const EmptyState(
+          icon: Icons.cloud_off_rounded,
+          message: 'Couldn’t load — try again from Settings',
+        );
+      case TrackerListStatus.idle:
+      case TrackerListStatus.ready:
+        if (tlState.entries.isEmpty) {
+          return const EmptyState(
+            icon: Icons.bookmark_outline,
+            message: 'No titles in this list',
+          );
+        }
+        final tracker = tlState.tracker!;
+        return _posterGrid(
+          entries: tlState.entries,
+          autofocusFirst: false,
+          onTap: (item) => _openTrackerItem(context, item),
+          onLongPress: (entry) {
+            showTrackerEntrySheet(
+              context,
+              tracker: tracker,
+              item: entry.item,
+              status: entry.status,
+              progress: entry.progress,
+              score: entry.score,
+              tmdbIsTv: entry.tmdbIsTv,
+              customLists: entry.customLists,
+              onFind: () => _openTrackerItem(context, entry.item),
+              onChanged: () => context.read<TrackerListCubit>().refresh(),
+            );
+          },
+        );
+    }
+  }
+
+  Widget _posterGrid({
+    required List<MyListEntry> entries,
+    required bool autofocusFirst,
+    required void Function(MediaItem) onTap,
+    required void Function(MyListEntry) onLongPress,
+  }) {
+    return GridView.builder(
+      // Top inset keeps focused poster scale/outline inside the grid instead
+      // of sliding up under the source-chip row (which paints beneath us).
+      padding: const EdgeInsets.fromLTRB(40, 12, 40, 40),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: _crossAxisCount,
+        childAspectRatio: 0.56,
+        crossAxisSpacing: 18,
+        mainAxisSpacing: 22,
+      ),
+      itemCount: entries.length,
+      itemBuilder: (context, i) {
+        final entry = entries[i];
+        return TvPosterTile(
+          autofocus: autofocusFirst && i == 0,
+          title: entry.item.title,
+          imageUrl: entry.item.cover,
+          headers: entry.item.coverHeaders,
+          onTap: () => onTap(entry.item),
+          onLongPress: () => onLongPress(entry),
+        );
+      },
+    );
+  }
+
+  /// Connected trackers for the current content mode, or empty when DI isn't
+  /// wired (widget tests that only exercise the local list).
+  static List<Tracker> _connectedTrackers() {
+    if (!sl.isRegistered<TrackerHub>() ||
+        !sl.isRegistered<ContentModeCubit>()) {
+      return const [];
+    }
+    return sl<TrackerHub>()
+        .connectedForMode(sl<ContentModeCubit>().state)
+        .toList();
+  }
+}
+
+/// Focusable source chips: My List + each connected tracker. Hidden when no
+/// trackers are connected so the local-only layout matches the old screen.
+class _SourceChips extends StatelessWidget {
+  const _SourceChips({required this.tlState});
+
+  final TrackerListState tlState;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!sl.isRegistered<TrackerHub>() ||
+        !sl.isRegistered<ContentModeCubit>()) {
+      return const SizedBox.shrink();
+    }
+    final hub = sl<TrackerHub>();
+    return AnimatedBuilder(
+      animation: Listenable.merge(hub.trackers),
+      builder: (context, _) {
+        final connected =
+            hub.connectedForMode(sl<ContentModeCubit>().state).toList();
+        if (connected.isEmpty) return const SizedBox.shrink();
+
+        final cubit = context.read<TrackerListCubit>();
+        // Same Row layout as Schedule's top tabs. Vertical padding reserves
+        // space for the float focus ring; Clip.none so horizontal scroll
+        // doesn't shave it. Keep bottom padding light — the grid supplies
+        // the gap below so posters don't sit under this row.
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(40, 8, 40, 4),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            clipBehavior: Clip.none,
+            child: Row(
+              children: [
+                TvFocusable(
+                  autofocus: true,
+                  variant: TvFocusVariant.float,
+                  scale: 1.0,
+                  borderRadius: 20,
+                  onTap: cubit.selectMyList,
+                  child: _Chip(
+                    label: 'My List',
+                    selected: tlState.isMyList,
+                  ),
+                ),
+                for (final t in connected) ...[
+                  const SizedBox(width: 12),
+                  TvFocusable(
+                    variant: TvFocusVariant.float,
+                    scale: 1.0,
+                    borderRadius: 20,
+                    onTap: () => cubit.selectTracker(t),
+                    child: _Chip(
+                      label: t.displayName == 'MyAnimeList'
+                          ? 'MAL'
+                          : t.displayName,
+                      selected: tlState.tracker == t,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  const _Chip({required this.label, required this.selected});
+  final String label;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+        decoration: BoxDecoration(
+          color: selected
+              ? AppColors.accent.withValues(alpha: 0.18)
+              : AppColors.surface2,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: selected ? AppColors.accent : Colors.transparent,
+            width: 2,
+          ),
+        ),
+        child: Text(
+          label,
+          style: AppText.headline.copyWith(
+            color: selected ? AppColors.accent : AppColors.textSecondary,
+            fontSize: 15,
+          ),
+        ),
+      );
 }

--- a/lib/features/settings/settings_screen_tv.dart
+++ b/lib/features/settings/settings_screen_tv.dart
@@ -67,8 +67,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
   ProviderRegistry get _registry => sl<ProviderRegistry>();
   CloudStreamManager get _csManager => sl<CloudStreamManager>();
 
-  Future<void> _push(Widget screen) =>
-      Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => screen));
+  Future<void> _push(Widget screen) => Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => screen));
 
   String _activeLabel(String activeId) {
     if (activeId.startsWith('cs:')) {
@@ -123,22 +122,15 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
   }
 
   Future<void> _addCloudStreamRepo() async {
-    final url = await showDialog<String>(
-      context: context,
-      builder: (_) => const _TvAddRepoDialog(),
-    );
+    final url = await showDialog<String>(context: context, builder: (_) => const _TvAddRepoDialog());
     if (url == null || url.isEmpty || !mounted) return;
     final messenger = ScaffoldMessenger.of(context);
     try {
       final count = await _csManager.addRepo(url);
-      messenger.showSnackBar(
-        SnackBar(content: Text('Added — $count CloudStream source(s) available')),
-      );
+      messenger.showSnackBar(SnackBar(content: Text('Added — $count CloudStream source(s) available')));
       if (mounted) setState(() {});
     } catch (e) {
-      messenger.showSnackBar(
-        SnackBar(content: Text('Failed to add repository: $e')),
-      );
+      messenger.showSnackBar(SnackBar(content: Text('Failed to add repository: $e')));
     }
   }
 
@@ -146,9 +138,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
     return BlocBuilder<AuthCubit, AuthState>(
       builder: (context, auth) {
         if (auth.isLoggedIn) {
-          final initial = auth.displayName.isNotEmpty
-              ? auth.displayName[0].toUpperCase()
-              : '?';
+          final initial = auth.displayName.isNotEmpty ? auth.displayName[0].toUpperCase() : '?';
           return SettingsCard(
             children: [
               TvListFocusable(
@@ -157,17 +147,12 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                 onTap: () => _push(const ProfileScreen()),
                 child: ExcludeSemantics(
                   child: ListTile(
-                    contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 16, vertical: 6),
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
                     leading: CircleAvatar(
                       radius: 22,
                       backgroundColor: AppColors.surface2,
-                      backgroundImage: auth.avatarUrl != null
-                          ? CachedNetworkImageProvider(auth.avatarUrl!)
-                          : null,
-                      child: auth.avatarUrl == null
-                          ? Text(initial, style: AppText.headline)
-                          : null,
+                      backgroundImage: auth.avatarUrl != null ? CachedNetworkImageProvider(auth.avatarUrl!) : null,
+                      child: auth.avatarUrl == null ? Text(initial, style: AppText.headline) : null,
                     ),
                     title: Text(
                       auth.displayName,
@@ -181,11 +166,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
-                    trailing: const Icon(
-                      Icons.chevron_right_rounded,
-                      color: AppColors.textTertiary,
-                      size: 22,
-                    ),
+                    trailing: const Icon(Icons.chevron_right_rounded, color: AppColors.textTertiary, size: 22),
                   ),
                 ),
               ),
@@ -225,10 +206,10 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
               child: ListView(
                 clipBehavior: Clip.none,
                 padding: const EdgeInsets.only(top: 4, bottom: 24),
-                
+
                 children: [
                   _accountCard(context),
-
+                  const SizedBox(height: 8),
                   SettingsCard(
                     children: [
                       SettingsTile(
@@ -239,7 +220,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                       ),
                     ],
                   ),
-
+                  const SizedBox(height: 8),
                   SettingsCard(
                     children: [
                       SettingsTile(
@@ -281,7 +262,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                       ],
                     ],
                   ),
-
+                  const SizedBox(height: 8),
                   SettingsCard(
                     children: [
                       SettingsTile(
@@ -312,15 +293,13 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                         SettingsTile(
                           icon: Icons.notifications_none_rounded,
                           title: 'Notifications',
-                          subtitle:
-                              'New-episode alerts for subscribed shows',
+                          subtitle: 'New-episode alerts for subscribed shows',
                           onTap: () => _push(const SubscriptionsScreen()),
                         ),
                         SettingsTile(
                           icon: Icons.update_rounded,
                           title: 'Source updates',
-                          subtitle:
-                              'Notify when installed sources have updates',
+                          subtitle: 'Notify when installed sources have updates',
                           onTap: () async {
                             final cm = sl<CloudStreamManager>();
                             await cm.setNotifyUpdates(!cm.notifyUpdates);
@@ -330,8 +309,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                             value: sl<CloudStreamManager>().notifyUpdates,
                             activeThumbColor: AppColors.accent,
                             onChanged: (v) async {
-                              await sl<CloudStreamManager>()
-                                  .setNotifyUpdates(v);
+                              await sl<CloudStreamManager>().setNotifyUpdates(v);
                               if (mounted) setState(() {});
                             },
                           ),
@@ -339,8 +317,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                         SettingsTile(
                           icon: Icons.science_outlined,
                           title: 'Beta updates',
-                          subtitle:
-                              'Get pre-release builds early — may be unstable',
+                          subtitle: 'Get pre-release builds early — may be unstable',
                           subtitleMaxLines: null,
                           onTap: () async {
                             final v = !_betaUpdates;
@@ -371,7 +348,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                       ],
                     ],
                   ),
-
+                  const SizedBox(height: 8),
                   SettingsCard(
                     children: [
                       SettingsTile(
@@ -381,7 +358,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                       ),
                     ],
                   ),
-
+                  const SizedBox(height: 8),
                   SettingsCard(
                     children: [
                       SettingsTile(
@@ -413,7 +390,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                       ),
                     ],
                   ),
-
+                  const SizedBox(height: 8),
                   SettingsCard(
                     children: [
                       SettingsTile(
@@ -427,11 +404,9 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                         title: 'Check for updates',
                         subtitle: 'Get the latest version from GitHub',
                         onTap: () {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Checking for updates…'),
-                            ),
-                          );
+                          ScaffoldMessenger.of(
+                            context,
+                          ).showSnackBar(const SnackBar(content: Text('Checking for updates…')));
                           maybeShowUpdateDialog(context, manual: true);
                         },
                       ),
@@ -439,8 +414,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
                         SettingsTile(
                           icon: Icons.speed_rounded,
                           title: 'ExoPlayer spike (dev)',
-                          subtitle:
-                              'SP0 — test SurfaceView playback smoothness',
+                          subtitle: 'SP0 — test SurfaceView playback smoothness',
                           onTap: () => _push(const TvExoSpikeScreen()),
                         ),
                       SettingsTile(
@@ -463,12 +437,7 @@ class _SettingsScreenTvState extends State<SettingsScreenTv> {
 
 /// D-pad option picker dialog (DNS / search layout).
 class _TvOptionPicker<T> extends StatelessWidget {
-  const _TvOptionPicker({
-    super.key,
-    required this.title,
-    required this.options,
-    required this.current,
-  });
+  const _TvOptionPicker({super.key, required this.title, required this.options, required this.current});
 
   final String title;
   final List<(T, String)> options;
@@ -488,10 +457,7 @@ class _TvOptionPicker<T> extends StatelessWidget {
           children: [
             Padding(
               padding: const EdgeInsets.fromLTRB(24, 20, 24, 12),
-              child: Text(
-                title,
-                style: AppText.title.copyWith(color: AppColors.textPrimary),
-              ),
+              child: Text(title, style: AppText.title.copyWith(color: AppColors.textPrimary)),
             ),
             const Divider(height: 1, color: AppColors.hairline),
             for (int i = 0; i < options.length; i++)
@@ -501,19 +467,11 @@ class _TvOptionPicker<T> extends StatelessWidget {
                 semanticLabel: options[i].$2,
                 child: ExcludeSemantics(
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 24, vertical: 14),
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
                     child: Row(
                       children: [
-                        Expanded(
-                          child: Text(options[i].$2, style: AppText.headline),
-                        ),
-                        if (options[i].$1 == current)
-                          Icon(
-                            Icons.check,
-                            color: AppColors.accent,
-                            size: 20,
-                          ),
+                        Expanded(child: Text(options[i].$2, style: AppText.headline)),
+                        if (options[i].$1 == current) Icon(Icons.check, color: AppColors.accent, size: 20),
                       ],
                     ),
                   ),
@@ -561,10 +519,7 @@ class _TvAddRepoDialogState extends State<_TvAddRepoDialog> {
               keyboardType: TextInputType.url,
               cursorColor: AppColors.accent,
               style: AppText.body.copyWith(color: AppColors.textPrimary),
-              decoration: const InputDecoration(
-                labelText: 'Repository URL',
-                hintText: 'https://.../repo.json',
-              ),
+              decoration: const InputDecoration(labelText: 'Repository URL', hintText: 'https://.../repo.json'),
               onSubmitted: (v) => Navigator.pop(context, v.trim()),
             ),
           ],
@@ -580,9 +535,7 @@ class _TvAddRepoDialogState extends State<_TvAddRepoDialog> {
               onPressed: () => Navigator.pop(context),
               child: Text(
                 'Cancel',
-                style: AppText.body.copyWith(
-                  color: focused ? Colors.black : AppColors.textSecondary,
-                ),
+                style: AppText.body.copyWith(color: focused ? Colors.black : AppColors.textSecondary),
               ),
             ),
           ),
@@ -594,12 +547,10 @@ class _TvAddRepoDialogState extends State<_TvAddRepoDialog> {
           builder: (focused) => ExcludeSemantics(
             child: FilledButton(
               style: FilledButton.styleFrom(
-                backgroundColor:
-                    focused ? Colors.black : AppColors.accent,
+                backgroundColor: focused ? Colors.black : AppColors.accent,
                 foregroundColor: Colors.white,
               ),
-              onPressed: () =>
-                  Navigator.pop(context, _controller.text.trim()),
+              onPressed: () => Navigator.pop(context, _controller.text.trim()),
               child: const Text('Add'),
             ),
           ),

--- a/test/features/home/my_list_screen_tv_test.dart
+++ b/test/features/home/my_list_screen_tv_test.dart
@@ -2,13 +2,19 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:watch_app/core/di/injector.dart';
+import 'package:watch_app/core/mode/content_mode.dart';
+import 'package:watch_app/core/mode/content_mode_cubit.dart';
 import 'package:watch_app/core/models/media_item.dart';
 import 'package:watch_app/core/models/provider_info.dart';
 import 'package:watch_app/core/models/watch_status.dart';
 import 'package:watch_app/core/playback/list_status_store.dart';
 import 'package:watch_app/core/playback/my_list.dart';
+import 'package:watch_app/core/tracker/tracker.dart';
+import 'package:watch_app/core/tracker/tracker_hub.dart';
 import 'package:watch_app/core/tv/tv_focusable.dart';
 import 'package:watch_app/features/home/cubit/my_list_cubit.dart';
+import 'package:watch_app/features/home/cubit/tracker_list_cubit.dart';
 import 'package:watch_app/features/home/my_list_screen_tv.dart';
 
 // ── Minimal fakes ─────────────────────────────────────────────────────────────
@@ -46,10 +52,93 @@ class _FakeListStatusStore implements ListStatusStore {
   noSuchMethod(Invocation i) => super.noSuchMethod(i);
 }
 
+class _FakeContentModeCubit extends Cubit<ContentMode>
+    implements ContentModeCubit {
+  _FakeContentModeCubit(super.initial);
+  @override
+  noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+/// Connected (or not) tracker stub for the TV source chips + fetch path.
+class _FakeTracker extends ChangeNotifier implements Tracker {
+  _FakeTracker({
+    required this.name,
+    this.connected = false,
+    this.list = const [],
+    this.supportsReading = true,
+  });
+
+  final String name;
+  final bool connected;
+  final List<TrackerListItem> list;
+
+  @override
+  final bool supportsReading;
+
+  @override
+  String get displayName => name;
+
+  @override
+  bool get isConnected => connected;
+
+  @override
+  String? get viewerName => connected ? 'viewer' : null;
+
+  @override
+  String? get viewerAvatar => null;
+
+  @override
+  bool get autoSync => true;
+
+  @override
+  set autoSync(bool value) {}
+
+  @override
+  Future<bool> connect() async => true;
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<List<TrackerListItem>> fetchList() async => list;
+
+  @override
+  noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+/// Lets tests emit an arbitrary [TrackerListState] without going through fetch.
+class _SeededTrackerListCubit extends TrackerListCubit {
+  void seed(TrackerListState state) => emit(state);
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 MyListCubit _makeCubit(List<MediaItem> items) =>
     MyListCubit(_FakeMyListStore(items), _FakeListStatusStore());
+
+Widget _pumpTree({
+  required MyListCubit myList,
+  required TrackerListCubit trackerList,
+}) {
+  return MultiBlocProvider(
+    providers: [
+      BlocProvider<MyListCubit>.value(value: myList),
+      BlocProvider<TrackerListCubit>.value(value: trackerList),
+    ],
+    child: const MaterialApp(home: MyListScreenTv()),
+  );
+}
+
+Future<void> _registerHub(List<Tracker> trackers) async {
+  if (sl.isRegistered<TrackerHub>()) await sl.unregister<TrackerHub>();
+  if (sl.isRegistered<ContentModeCubit>()) {
+    await sl.unregister<ContentModeCubit>();
+  }
+  sl.registerSingleton<TrackerHub>(TrackerHub(trackers));
+  sl.registerSingleton<ContentModeCubit>(
+    _FakeContentModeCubit(ContentMode.anime),
+  );
+}
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -68,35 +157,45 @@ void main() {
     type: ProviderType.anime,
     sourceId: 'test',
   );
+  const trackerItem = MediaItem(
+    id: 'al-99',
+    title: 'Jujutsu Kaisen',
+    url: '',
+    type: ProviderType.anime,
+    sourceId: '',
+  );
+
+  setUp(() async {
+    await sl.reset();
+  });
+
+  tearDown(() async {
+    await sl.reset();
+  });
 
   testWidgets(
     'MyListScreenTv renders poster cards and first card has autofocus',
     (tester) async {
-      final cubit = _makeCubit([item1, item2]);
-      addTearDown(cubit.close);
+      // No connected trackers → chip row hidden → first poster autofocuses.
+      await _registerHub([_FakeTracker(name: 'AniList', connected: false)]);
 
-      await tester.pumpWidget(
-        BlocProvider<MyListCubit>.value(
-          value: cubit,
-          child: const MaterialApp(home: MyListScreenTv()),
-        ),
-      );
+      final cubit = _makeCubit([item1, item2]);
+      final tlCubit = TrackerListCubit();
+      addTearDown(cubit.close);
+      addTearDown(tlCubit.close);
+
+      await tester.pumpWidget(_pumpTree(myList: cubit, trackerList: tlCubit));
       await tester.pumpAndSettle();
 
-      // Both titles are rendered as poster cards.
       expect(find.text('Attack on Titan'), findsOneWidget);
       expect(find.text('Demon Slayer'), findsOneWidget);
+      // No tracker chips when nothing is connected.
+      expect(find.text('AniList'), findsNothing);
 
-      // At least 2 TvFocusable cards are present.
       final focusables =
           tester.widgetList<TvFocusable>(find.byType(TvFocusable)).toList();
       expect(focusables.length, greaterThanOrEqualTo(2));
-
-      // The very first TvFocusable (first poster card) has autofocus=true.
       expect(focusables.first.autofocus, isTrue);
-
-      // Held OK on a card must have a long-press handler (status / remove),
-      // matching phone long-press. Without this, TvFocusable treats OK as tap.
       expect(focusables.first.onLongPress, isNotNull);
     },
   );
@@ -104,20 +203,135 @@ void main() {
   testWidgets(
     'MyListScreenTv shows empty state when cubit emits no entries',
     (tester) async {
-      final cubit = _makeCubit([]);
-      addTearDown(cubit.close);
+      await _registerHub(const []);
 
-      await tester.pumpWidget(
-        BlocProvider<MyListCubit>.value(
-          value: cubit,
-          child: const MaterialApp(home: MyListScreenTv()),
-        ),
-      );
+      final cubit = _makeCubit([]);
+      final tlCubit = TrackerListCubit();
+      addTearDown(cubit.close);
+      addTearDown(tlCubit.close);
+
+      await tester.pumpWidget(_pumpTree(myList: cubit, trackerList: tlCubit));
       await tester.pumpAndSettle();
 
-      // No poster cards — empty state message visible.
       expect(find.text('Titles you add appear here'), findsOneWidget);
       expect(find.byType(TvFocusable), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'connected tracker shows a source chip; selecting it shows tracker titles',
+    (tester) async {
+      final anilist = _FakeTracker(
+        name: 'AniList',
+        connected: true,
+        list: [
+          const TrackerListItem(
+            item: trackerItem,
+            status: WatchStatus.watching,
+          ),
+        ],
+      );
+      await _registerHub([anilist]);
+
+      final cubit = _makeCubit([item1]);
+      final tlCubit = TrackerListCubit();
+      addTearDown(cubit.close);
+      addTearDown(tlCubit.close);
+
+      await tester.pumpWidget(_pumpTree(myList: cubit, trackerList: tlCubit));
+      await tester.pumpAndSettle();
+
+      // Chips for My List + AniList; local title still showing.
+      expect(find.text('My List'), findsWidgets);
+      expect(find.text('AniList'), findsOneWidget);
+      expect(find.text('Attack on Titan'), findsOneWidget);
+      expect(find.text('Jujutsu Kaisen'), findsNothing);
+
+      // First focusable is the My List chip (autofocus when chips exist).
+      final focusables =
+          tester.widgetList<TvFocusable>(find.byType(TvFocusable)).toList();
+      expect(focusables.first.autofocus, isTrue);
+
+      await tester.tap(find.text('AniList'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Jujutsu Kaisen'), findsOneWidget);
+      expect(find.text('Attack on Titan'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'tracker loading state shows a progress indicator',
+    (tester) async {
+      final anilist = _FakeTracker(name: 'AniList', connected: true);
+      await _registerHub([anilist]);
+
+      final cubit = _makeCubit([item1]);
+      final tlCubit = _SeededTrackerListCubit()
+        ..seed(TrackerListState(
+          source: TrackerSource(anilist),
+          status: TrackerListStatus.loading,
+        ));
+      addTearDown(cubit.close);
+      addTearDown(tlCubit.close);
+
+      await tester.pumpWidget(_pumpTree(myList: cubit, trackerList: tlCubit));
+      // One frame only — pumpAndSettle never completes on an indeterminate
+      // CircularProgressIndicator.
+      await tester.pump();
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tracker empty and error states show dedicated copy',
+    (tester) async {
+      final anilist = _FakeTracker(name: 'AniList', connected: true);
+      await _registerHub([anilist]);
+
+      final cubit = _makeCubit([item1]);
+      final tlCubit = _SeededTrackerListCubit()
+        ..seed(TrackerListState(
+          source: TrackerSource(anilist),
+          status: TrackerListStatus.ready,
+          entries: const [],
+        ));
+      addTearDown(cubit.close);
+      addTearDown(tlCubit.close);
+
+      await tester.pumpWidget(_pumpTree(myList: cubit, trackerList: tlCubit));
+      await tester.pumpAndSettle();
+      expect(find.text('No titles in this list'), findsOneWidget);
+
+      tlCubit.seed(TrackerListState(
+        source: TrackerSource(anilist),
+        status: TrackerListStatus.error,
+      ));
+      await tester.pumpAndSettle();
+      expect(
+        find.text('Couldn’t load — try again from Settings'),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'MAL chip uses short label',
+    (tester) async {
+      await _registerHub([
+        _FakeTracker(name: 'MyAnimeList', connected: true),
+      ]);
+
+      final cubit = _makeCubit([item1]);
+      final tlCubit = TrackerListCubit();
+      addTearDown(cubit.close);
+      addTearDown(tlCubit.close);
+
+      await tester.pumpWidget(_pumpTree(myList: cubit, trackerList: tlCubit));
+      await tester.pumpAndSettle();
+
+      expect(find.text('MAL'), findsOneWidget);
+      expect(find.text('MyAnimeList'), findsNothing);
     },
   );
 }


### PR DESCRIPTION
## Summary
- TV My List now switches between the local list and connected AniList / MAL / Simkl libraries via D-pad source chips (`TrackerListCubit`), matching phone behavior for [#41](https://github.com/Spyou/Zangetsu/issues/41).
- Tracker poster long-press opens a TV-focusable entry sheet (status, progress, score, remove); Apply uses a visible white-outline focus on the accent button.
- Chip/grid spacing keeps float focus rings from clipping under the poster grid; widget tests cover local-only, connected chips, and loading/empty/error states.

## Test plan
- [ ] On TV with no trackers connected: My List shows only local titles, no source chips
- [ ] Connect AniList (and/or MAL / Simkl) in Settings → My List shows source chips
- [ ] Select AniList/MAL/Simkl chip → tracker library loads; empty/error states show the right copy
- [ ] OK on a tracker poster opens Search with that title; held OK opens the entry sheet and Apply/Remove work with the D-pad
- [ ] Source chip focus rings are fully visible (not clipped by the poster grid)
- [ ] `fvm flutter test test/features/home/my_list_screen_tv_test.dart`

## Screenshots
<img width="800" height="453" alt="CleanShot 2026-08-25 at 11 02 54" src="https://github.com/user-attachments/assets/cd27d140-27fe-480c-87f5-cba91ac600ec" />
