### PR TITLE
fix(tv): TV tracker QR login + deeplink Have the app QRs

### DIFF
--- a/lib/core/environment.dart
+++ b/lib/core/environment.dart
@@ -33,9 +33,9 @@ class Environment {
   /// must be an Appwrite Web platform (already added for the reset page).
   static const String siteOpenUrl = '$siteBaseUrl/open/';
 
-  /// TV pairing QR. iPhone Camera only treats http(s) as a link, so the TV
-  /// encodes this URL (not `zangetsu://pair`). The page is the phone login +
-  /// approve flow — same `pair-tv` approve the Android app uses.
+  /// TV pairing page on the website. Used when someone opens a shared/https
+  /// pair link in a browser; the page can hand off to the app via
+  /// `zangetsu://pair`. App-facing TV QRs encode the deeplink directly.
   static const String sitePairUrl = '$siteBaseUrl/pair/';
 
   /// The "open" page redirects to `zangetsu://open?…`; an installed app catches

--- a/lib/core/share/open_link_service.dart
+++ b/lib/core/share/open_link_service.dart
@@ -13,7 +13,7 @@ import 'pair_link.dart';
 import 'share_link.dart';
 
 /// Listens for incoming share links (`zangetsu://open?…`) and pairing links
-/// (`https://zangetsu.online/pair/?…` or `zangetsu://pair?…`) and opens the
+/// (`zangetsu://pair?…` or `https://zangetsu.online/pair/?…`) and opens the
 /// matching screen. Tracker OAuth listeners share the same [AppLinks] stream
 /// and ignore anything they don't own.
 class OpenLinkService {
@@ -29,8 +29,8 @@ class OpenLinkService {
   StreamSubscription<Uri>? _sub;
 
   void _onLink(Uri uri) {
-    // HTTPS /pair/?code=… (iPhone Camera) or zangetsu://pair?code=… (site
-    // redirect / Android custom-scheme). Same payload either way.
+    // zangetsu://pair?code=… (TV QR) or HTTPS /pair/?code=… (web share /
+    // landing page). Same payload either way.
     final pair = PairLink.parse(uri);
     if (pair != null) {
       if (pair.trackers) {

--- a/lib/core/share/pair_link.dart
+++ b/lib/core/share/pair_link.dart
@@ -1,8 +1,7 @@
 import '../environment.dart';
 
-/// Encodes the TV pairing QR as an HTTPS URL (iPhone Camera rejects custom
-/// schemes with "No usable data found") and parses incoming pair links from
-/// either the website or the `zangetsu://pair` redirect it fires.
+/// Encodes TV pairing links and parses incoming pair URLs from either the
+/// website (`https://zangetsu.online/pair/…`) or the `zangetsu://pair` deeplink.
 class PairLink {
   const PairLink({this.code, this.nonce, this.trackers = false});
 
@@ -12,8 +11,7 @@ class PairLink {
   /// When true this is the trackers-only QR (Flow B), not account sign-in.
   final bool trackers;
 
-  /// Payload printed in the TV QR. An http(s) URL so iPhone Camera treats it
-  /// as a link instead of "No usable data found".
+  /// HTTPS pair URL for web/share links (browser → optional app handoff).
   static String qrData({
     required String code,
     String? nonce,
@@ -24,8 +22,8 @@ class PairLink {
     ).toString();
   }
 
-  /// Custom-scheme link the `/pair/` landing page (and Android intent-filters)
-  /// hand off to [OpenLinkService].
+  /// Custom-scheme deeplink for TV "have the app" QRs and Android intent-filters.
+  /// Handled by [OpenLinkService].
   static String deepLink({
     required String code,
     String? nonce,

--- a/lib/features/auth/pair_tv_screen.dart
+++ b/lib/features/auth/pair_tv_screen.dart
@@ -11,9 +11,9 @@ import 'auth_cubit.dart';
 import 'tv_pairing_service.dart';
 
 /// Phone: approve a TV pairing. Enter the code shown on the TV (or arrive here
-/// via the pairing QR — `https://zangetsu.online/pair/?code=…`, forwarded to
-/// `zangetsu://pair`), confirm the device, and sign the TV into this account.
-/// Requires the phone to be signed in.
+/// via the pairing QR — `zangetsu://pair?code=…`, or an https `/pair/` link
+/// forwarded to that deeplink), confirm the device, and sign the TV into this
+/// account. Requires the phone to be signed in.
 class PairTvScreen extends StatefulWidget {
   const PairTvScreen({super.key, this.initialCode, this.nonce});
   final String? initialCode;

--- a/lib/features/auth/tv_pair_screen.dart
+++ b/lib/features/auth/tv_pair_screen.dart
@@ -161,9 +161,8 @@ class _TvPairScreenState extends State<TvPairScreen> {
               borderRadius: BorderRadius.circular(16),
             ),
             child: QrImageView(
-              // https://… — iPhone Camera rejects custom schemes with
-              // "No usable data found". The /pair/ page is the web login.
-              data: PairLink.qrData(code: _code ?? '', nonce: _nonce),
+              // Deeplink so an installed phone app opens Pair a TV directly.
+              data: PairLink.deepLink(code: _code ?? '', nonce: _nonce),
               size: 220,
               gapless: true,
             ),

--- a/lib/features/auth/tv_tracker_connect_screen.dart
+++ b/lib/features/auth/tv_tracker_connect_screen.dart
@@ -134,12 +134,11 @@ class _TvTrackerConnectScreenState extends State<TvTrackerConnectScreen> {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      // QR 1 — phone-app relay. HTTPS so iPhone Camera treats
-                      // it as a link (custom schemes show "No usable data
-                      // found"). The /pair/ page then opens the app, which
-                      // approves and relays this $_label session to the TV.
+                      // QR 1 — phone-app relay via deeplink. Opens the installed
+                      // app directly so it can approve and relay this $_label
+                      // session to the TV.
                       _qrOption(
-                        data: PairLink.qrData(
+                        data: PairLink.deepLink(
                           code: _code!,
                           nonce: _nonce,
                           trackers: true,


### PR DESCRIPTION
## Summary
- Fixes TV “Have the app?” / sign-in QRs to encode `zangetsu://pair` deeplinks so the installed phone app opens pairing directly (#51).
- **MyAnimeList / tracker OAuth redirect URLs were updated in the provider API dashboards** (add `https://zangetsu.online/tv-connect/` alongside the existing `zangetsu://…` app schemes). That config change is required for the “No app?” browser login path; **there is no commit for it** because it lives outside the repo.

## Test plan
- [ ] TV → Connect MyAnimeList → “No app?” QR → phone browser login completes and TV shows connected (depends on MAL redirect URI already registered)
- [ ] Same for AniList / Simkl “No app?” path if those redirect URIs were updated too
- [ ] TV → Connect tracker → “Have the app?” QR opens the phone app into the trackers-only relay flow
- [ ] TV account pair QR opens the phone app into Pair a TV
- [ ] Mobile app MAL/AniList/Simkl login still works with the existing custom-scheme redirects