### PR TITLE
feat(tv): Audio/Subs Settings, Captions Styling, and speed pill (#48)

### DIFF
--- a/android/app/src/main/kotlin/com/spyou/watch_app/ExoPlayerView.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/ExoPlayerView.kt
@@ -12,9 +12,12 @@ import android.view.View
 import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionOverride
+import androidx.media3.common.text.Cue
+import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
@@ -74,6 +77,8 @@ class ExoPlayerView(
     private var sink: EventChannel.EventSink? = null
 
     private val handler = Handler(Looper.getMainLooper())
+    /** PlaybackPrefs subtitlePosition 0=top … 100=bottom; drives cue line remapping. */
+    private var captionPositionPref = 95
     private val tick = object : Runnable {
         override fun run() {
             emitState()
@@ -94,6 +99,9 @@ class ExoPlayerView(
             override fun onPlaybackStateChanged(state: Int) { syncKeepScreenOn(); emitState() }
             override fun onIsPlayingChanged(isPlaying: Boolean) { syncKeepScreenOn(); emitState() }
             override fun onTracksChanged(tracks: androidx.media3.common.Tracks) = emitState()
+            override fun onCues(cueGroup: CueGroup) {
+                playerView.subtitleView?.setCues(repositionCues(cueGroup.cues))
+            }
         })
         syncKeepScreenOn()
         handler.post(tick)
@@ -128,7 +136,16 @@ class ExoPlayerView(
                 )
                 when (g.type) {
                     C.TRACK_TYPE_AUDIO -> audio.add(entry)
-                    C.TRACK_TYPE_TEXT -> text.add(entry)
+                    C.TRACK_TYPE_TEXT -> {
+                        // Hide in-band CEA-608/708 from the picker — unlabeled
+                        // "Subtitle 1" rows that do nothing useful for softsubs.
+                        val mime = f.sampleMimeType
+                        if (mime != MimeTypes.APPLICATION_CEA608 &&
+                            mime != MimeTypes.APPLICATION_CEA708
+                        ) {
+                            text.add(entry)
+                        }
+                    }
                     C.TRACK_TYPE_VIDEO -> if (g.isTrackSupported(ti)) {
                         // Height is what labels the row, so a rendition that
                         // doesn't report one is no use as a choice.
@@ -177,14 +194,21 @@ class ExoPlayerView(
         val fontPath = call.argument<String>("fontPath")
         val fg = (call.argument<Number>("fgColor") ?: -1).toInt()
         val bg = (call.argument<Number>("bgColor") ?: 0).toInt()
-        val edge = call.argument<Boolean>("edge") ?: false
-        val pos = (call.argument<Number>("position") ?: 0.05).toDouble()
+        val edgeType = call.argument<Number>("edgeType")?.toInt()
+            ?: if (call.argument<Boolean>("edge") == true) {
+                CaptionStyleCompat.EDGE_TYPE_OUTLINE
+            } else {
+                CaptionStyleCompat.EDGE_TYPE_NONE
+            }
+        captionPositionPref = (call.argument<Number>("positionPref") ?: 95)
+            .toInt()
+            .coerceIn(0, 100)
         val tf = fontPath?.let { runCatching { Typeface.createFromFile(it) }.getOrNull() }
         val style = CaptionStyleCompat(
             fg,
             bg,
             Color.TRANSPARENT,
-            if (edge) CaptionStyleCompat.EDGE_TYPE_OUTLINE else CaptionStyleCompat.EDGE_TYPE_NONE,
+            edgeType,
             Color.BLACK,
             tf,
         )
@@ -193,7 +217,21 @@ class ExoPlayerView(
             setApplyEmbeddedFontSizes(false)
             setStyle(style)
             setFractionalTextSize(SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * scale.toFloat())
-            setBottomPaddingFraction(pos.toFloat())
+            // Cue lines are remapped in [repositionCues]; pad alone is ignored
+            // when the cue already has a line.
+            setBottomPaddingFraction(0.02f)
+        }
+        playerView.subtitleView?.setCues(repositionCues(player.currentCues.cues))
+    }
+
+    private fun repositionCues(cues: List<Cue>): List<Cue> {
+        if (cues.isEmpty()) return cues
+        val line = captionPositionPref.coerceIn(0, 100) / 100f
+        return cues.map { cue ->
+            cue.buildUpon()
+                .setLine(line, Cue.LINE_TYPE_FRACTION)
+                .setLineAnchor(Cue.ANCHOR_TYPE_END)
+                .build()
         }
     }
 

--- a/android/app/src/main/kotlin/com/spyou/watch_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/MainActivity.kt
@@ -1344,7 +1344,27 @@ class MainActivity : AppCompatActivity(), FlutterEngineConfigurator {
             intent.putExtra(TvPlayerActivity.EXTRA_SUB_FG, (call.argument<Number>("subtitleFgColor") ?: -1).toInt())
             intent.putExtra(TvPlayerActivity.EXTRA_SUB_BG_COLOR, (call.argument<Number>("subtitleBgColor") ?: 0).toInt())
             intent.putExtra(TvPlayerActivity.EXTRA_SUB_EDGE, call.argument<Boolean>("subtitleEdge") ?: true)
-            intent.putExtra(TvPlayerActivity.EXTRA_SUB_POS, (call.argument<Number>("subtitlePosition") ?: 0.05).toFloat())
+            val edgeTypeArg = call.argument<Number>("subtitleEdgeType")
+            val edgeType = edgeTypeArg?.toInt()
+                ?: if (call.argument<Boolean>("subtitleEdge") == true) 1 else 0
+            intent.putExtra(TvPlayerActivity.EXTRA_SUB_EDGE_TYPE, edgeType)
+            call.argument<String>("subtitleColorHex")?.let {
+                intent.putExtra(TvPlayerActivity.EXTRA_SUB_COLOR_HEX, it)
+            }
+            call.argument<String>("subtitleOutlineType")?.let {
+                intent.putExtra(TvPlayerActivity.EXTRA_SUB_OUTLINE_TYPE, it)
+            }
+            call.argument<String>("subtitleFontFamily")?.let {
+                intent.putExtra(TvPlayerActivity.EXTRA_SUB_FONT_FAMILY, it)
+            }
+            intent.putExtra(
+                TvPlayerActivity.EXTRA_SUB_POS_PREF,
+                (call.argument<Number>("subtitlePositionPref") ?: 95).toInt(),
+            )
+            intent.putExtra(
+                TvPlayerActivity.EXTRA_SUB_BG_OPACITY,
+                (call.argument<Number>("subtitleBgOpacity") ?: 0.0).toFloat(),
+            )
             call.argument<String>("subtitleFontPath")?.let { intent.putExtra(TvPlayerActivity.EXTRA_SUB_FONT, it) }
             intent.putExtra(TvPlayerActivity.EXTRA_SUB_HAS_KEY, call.argument<Boolean>("subtitleApiKeySet") ?: false)
             intent.putExtra(TvPlayerActivity.EXTRA_MEGASKIP, call.argument<Boolean>("megaSkip") ?: true)

--- a/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
@@ -21,6 +21,8 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.Tracks
+import androidx.media3.common.text.Cue
+import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
@@ -79,7 +81,12 @@ class TvPlayerActivity : Activity() {
         const val EXTRA_SUB_FG = "subtitleFgColor"
         const val EXTRA_SUB_BG_COLOR = "subtitleBgColor"
         const val EXTRA_SUB_EDGE = "subtitleEdge"
-        const val EXTRA_SUB_POS = "subtitlePosition"
+        const val EXTRA_SUB_EDGE_TYPE = "subtitleEdgeType"
+        const val EXTRA_SUB_COLOR_HEX = "subtitleColorHex"
+        const val EXTRA_SUB_OUTLINE_TYPE = "subtitleOutlineType"
+        const val EXTRA_SUB_FONT_FAMILY = "subtitleFontFamily"
+        const val EXTRA_SUB_POS_PREF = "subtitlePositionPref"
+        const val EXTRA_SUB_BG_OPACITY = "subtitleBgOpacity"
         const val EXTRA_SUB_FONT = "subtitleFontPath"
         const val EXTRA_SUB_HAS_KEY = "subtitleApiKeySet"
         const val EXTRA_EP_LABELS = "episodeLabels"
@@ -159,6 +166,7 @@ class TvPlayerActivity : Activity() {
     private lateinit var btnAudioSubs: TextView
     private lateinit var btnNext: TextView
     private lateinit var btnMegaskip: TextView
+    private lateinit var btnSpeed: TextView
     // MegaSkip jump size in seconds (read from the launch extras).
     private var megaSkipSecs = 85
     // Whether the AniSkip "Skip intro/ending" pill may show (Settings toggle).
@@ -176,10 +184,34 @@ class TvPlayerActivity : Activity() {
     private val autoSkipped = HashSet<Long>()
     // Live subtitle size multiplier (seeded from prefs; changeable in-player).
     private var subScale = 1f
+    private var subFg = android.graphics.Color.WHITE
+    private var subBgColor = android.graphics.Color.TRANSPARENT
+    private var subEdgeType = CaptionStyleCompat.EDGE_TYPE_OUTLINE
+    private var subFontPath: String? = null
+    private var subFontFamily = ""
+    private var subBgOpacity = 0f
+    private var subOutlineId = "outline"
+    private var subColorHex = "#FFFFFFFF"
+    private var subPositionPref = 95
     private lateinit var fillerBadge: TextView
 
     private lateinit var menuPanel: View
     private lateinit var menuContent: android.widget.LinearLayout
+
+    /** Drill-in pages for the Audio & Subs Settings panel. */
+    private enum class AvPage {
+        ROOT, AUDIO, SUBS, CAPTION_STYLE, SIZE, COLOR, EDGE, BG, FONT, POS, VOLUME
+    }
+    private val avStack = ArrayDeque<AvPage>()
+    private var avMenuActive = false
+    /**
+     * Optimistic subtitle selection for the Settings UI. ExoPlayer's
+     * [Tracks.Group.isTrackSelected] often lags one interaction behind when we
+     * rebuild the menu, so the checkmark would land on the *previous* pick.
+     * [textUiForcedOff] = Off; [textUiLabel] non-null = that track; both clear → trust Exo.
+     */
+    private var textUiForcedOff = false
+    private var textUiLabel: String? = null
 
     private var controlsVisible = false
     private var focusZone = 0 // 0 = none (OK=play/pause, ◀▶=seek), 1 = top actions, 2 = bottom
@@ -244,6 +276,28 @@ class TvPlayerActivity : Activity() {
         autoSkipFiller = intent.getBooleanExtra(EXTRA_AUTO_SKIP_FILLER, false)
         fillerFlags = intent.getBooleanArrayExtra(EXTRA_FILLER_FLAGS) ?: BooleanArray(0)
         subScale = intent.getFloatExtra(EXTRA_SUB_SCALE, 1f)
+        subFg = intent.getIntExtra(EXTRA_SUB_FG, android.graphics.Color.WHITE)
+        subBgColor = intent.getIntExtra(EXTRA_SUB_BG_COLOR, android.graphics.Color.TRANSPARENT)
+        subEdgeType = intent.getIntExtra(
+            EXTRA_SUB_EDGE_TYPE,
+            if (intent.getBooleanExtra(EXTRA_SUB_EDGE, true)) {
+                CaptionStyleCompat.EDGE_TYPE_OUTLINE
+            } else {
+                CaptionStyleCompat.EDGE_TYPE_NONE
+            },
+        )
+        subOutlineId = intent.getStringExtra(EXTRA_SUB_OUTLINE_TYPE) ?: when (subEdgeType) {
+            CaptionStyleCompat.EDGE_TYPE_NONE -> "none"
+            CaptionStyleCompat.EDGE_TYPE_DROP_SHADOW -> "shadow"
+            CaptionStyleCompat.EDGE_TYPE_RAISED -> "raised"
+            CaptionStyleCompat.EDGE_TYPE_DEPRESSED -> "depressed"
+            else -> "outline"
+        }
+        subPositionPref = intent.getIntExtra(EXTRA_SUB_POS_PREF, 95).coerceIn(0, 100)
+        subBgOpacity = intent.getFloatExtra(EXTRA_SUB_BG_OPACITY, ((subBgColor ushr 24) and 0xFF) / 255f)
+        subColorHex = intent.getStringExtra(EXTRA_SUB_COLOR_HEX) ?: "#FFFFFFFF"
+        subFontPath = intent.getStringExtra(EXTRA_SUB_FONT)
+        subFontFamily = intent.getStringExtra(EXTRA_SUB_FONT_FAMILY) ?: ""
         subtitleApiKeySet = intent.getBooleanExtra(EXTRA_SUB_HAS_KEY, false)
 
         setContentView(R.layout.tv_player)
@@ -275,7 +329,7 @@ class TvPlayerActivity : Activity() {
         speed = intent.getFloatExtra(EXTRA_SPEED, 1f)
         exo.playbackParameters = PlaybackParameters(speed)
         applyVolume(intent.getIntExtra(EXTRA_VOLUME, 100))
-        applySubtitleStyle()
+        applySubtitleStyleLive()
 
         exo.addListener(object : Player.Listener {
             override fun onRenderedFirstFrame() {
@@ -312,6 +366,11 @@ class TvPlayerActivity : Activity() {
                     loadEpisode(nextAutoplayIndex())
                 }
             }
+            // PlayerView also writes cues; we register after it so this wins and
+            // can force vertical position (embedded cue lines ignore bottom pad).
+            override fun onCues(cueGroup: CueGroup) {
+                playerView.subtitleView?.setCues(repositionCues(cueGroup.cues))
+            }
         })
 
         // First episode: stream data comes straight from the intent (Dart resolved
@@ -344,6 +403,7 @@ class TvPlayerActivity : Activity() {
     ) {
         val p = player ?: return
         userPaused = false
+        clearTextUiOverride() // new stream → trust Exo again
         currentUrl = url
         currentHeaders = headers
         currentMime = mime
@@ -734,6 +794,11 @@ class TvPlayerActivity : Activity() {
         menuOpener = opener
         firstSelectedRow = null
         focusTarget = null
+        // Quality / Sources / Episodes are flat menus — not the AV stack.
+        if (opener !== btnAudioSubs) {
+            avMenuActive = false
+            avStack.clear()
+        }
         menuContent.removeAllViews()
         build()
         showPanel()
@@ -748,14 +813,13 @@ class TvPlayerActivity : Activity() {
     /** Sources — the full resolved stream/mirror list. */
     private fun openSourcesMenu() = showMenu(btnSources) { buildSourcesMenu() }
 
-    /** Audio / Sub-Dub / Subtitles / Speed / Volume. */
-    private fun openAvMenu() = showMenu(btnAudioSubs) { buildAvMenu() }
-
     /** The "Episodes" list — jump to any episode via the same bridge switch. */
     private fun openEpisodes() {
         menuOpener = btnEpisodes
         firstSelectedRow = null
         focusTarget = null
+        avMenuActive = false
+        avStack.clear()
         menuContent.removeAllViews()
         sectionHeader("Episodes")
         for (i in 0 until episodeCount) {
@@ -774,6 +838,8 @@ class TvPlayerActivity : Activity() {
 
     private fun closeMenu() {
         menuOpen = false
+        avMenuActive = false
+        avStack.clear()
         menuPanel.visibility = View.GONE
         menuContent.removeAllViews()
         bumpControls()
@@ -841,84 +907,472 @@ class TvPlayerActivity : Activity() {
         }
     }
 
-    /** The "Audio & Subs" button's menu. */
-    private fun buildAvMenu() {
+    /** Audio / Subtitles / Captions Styling / Volume — Crunchyroll-style Settings. */
+    private fun openAvMenu() {
+        avMenuActive = true
+        avStack.clear()
+        showMenu(btnAudioSubs) { buildAvPage(AvPage.ROOT) }
+    }
+
+    private fun pushAv(page: AvPage) {
+        avStack.addLast(page)
+        rebuildAvMenuDeferred()
+    }
+
+    private fun popAvOrClose() {
+        if (avStack.isNotEmpty()) {
+            avStack.removeLast()
+            rebuildAvMenuDeferred()
+        } else {
+            closeMenu()
+        }
+    }
+
+    private fun rebuildAvMenu() {
+        firstSelectedRow = null
+        focusTarget = null
+        menuContent.removeAllViews()
+        val page = avStack.lastOrNull() ?: AvPage.ROOT
+        buildAvPage(page)
+        menuContent.post {
+            (focusTarget ?: firstSelectedRow ?: firstFocusable(menuContent))?.requestFocus()
+        }
+    }
+
+    /** Rebuild after the current click/key event finishes. Rebuilding the menu
+     *  hierarchy mid-click lets the event fall through to the row below — which
+     *  showed up as "I selected English but Spanish got the checkmark". */
+    private fun rebuildAvMenuDeferred() {
+        menuContent.post { rebuildAvMenu() }
+    }
+
+    private fun buildAvPage(page: AvPage) {
+        when (page) {
+            AvPage.ROOT -> buildAvRoot()
+            AvPage.AUDIO -> buildAvAudio()
+            AvPage.SUBS -> buildAvSubs()
+            AvPage.CAPTION_STYLE -> buildCaptionStyleRoot()
+            AvPage.SIZE -> buildCaptionSize()
+            AvPage.COLOR -> buildCaptionColor()
+            AvPage.EDGE -> buildCaptionEdge()
+            AvPage.BG -> buildCaptionBg()
+            AvPage.FONT -> buildCaptionFont()
+            AvPage.POS -> buildCaptionPos()
+            AvPage.VOLUME -> buildAvVolume()
+        }
+    }
+
+    private fun menuTitle(title: String) {
+        menuContent.addView(TextView(this).apply {
+            text = title
+            setTextColor(android.graphics.Color.WHITE)
+            textSize = 22f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+            setPadding(dp(4), dp(2), 0, dp(18))
+        })
+    }
+
+    private fun buildAvRoot() {
         val p = player ?: return
+        menuTitle("Settings")
         val groups = p.currentTracks.groups
 
-        // Audio tracks.
-        addTrackSection("Audio", groups, C.TRACK_TYPE_AUDIO) { f, idx ->
-            f.label ?: langName(f.language) ?: "Audio ${idx + 1}"
-        }
+        val audioLabel = selectedTrackLabel(groups, C.TRACK_TYPE_AUDIO)
+            ?: if (category == "dub") "Dub" else "Sub"
+        navRow("Audio", audioLabel) { pushAv(AvPage.AUDIO) }
 
-        // Sub / Dub (Version).
-        if (availableCategories.size > 1) {
-            sectionHeader("Sub / Dub")
-            for (c in availableCategories) {
-                option(if (c == "dub") "Dub" else "Sub", selected = c == category) { switchCategory(c) }
-            }
-        }
+        val textDisabled = p.trackSelectionParameters.disabledTrackTypes.contains(C.TRACK_TYPE_TEXT)
+        navRow("Subtitles/CC", subtitleTrailingLabel(groups, textDisabled)) { pushAv(AvPage.SUBS) }
 
-        // Subtitles (+ Off).
-        val text = groups.filter { it.type == C.TRACK_TYPE_TEXT }
-        val textTracks = text.flatMap { g -> (0 until g.length).map { g to it } }
-        if (textTracks.isNotEmpty()) {
-            val textDisabled = p.trackSelectionParameters.disabledTrackTypes.contains(C.TRACK_TYPE_TEXT)
-            sectionHeader("Subtitles")
-            option("Off", selected = textDisabled) {
-                p.trackSelectionParameters = p.trackSelectionParameters.buildUpon()
-                    .clearOverridesOfType(C.TRACK_TYPE_TEXT)
-                    .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true).build()
-            }
-            for ((g, i) in textTracks) {
+        navRow("Captions Styling", null) { pushAv(AvPage.CAPTION_STYLE) }
+
+        val volLabel = if (volumePercent == 100) "100%" else "$volumePercent%"
+        navRow("Volume", volLabel) { pushAv(AvPage.VOLUME) }
+    }
+
+    private fun selectedTrackLabel(groups: List<Tracks.Group>, type: Int): String? {
+        val gs = groups.filter { it.type == type && it.isSupported }
+        for (g in gs) {
+            for (i in 0 until g.length) {
+                if (!g.isTrackSelected(i)) continue
                 val f = g.getTrackFormat(i)
-                val label = f.label ?: langName(f.language) ?: "Subtitle ${i + 1}"
-                option(label, selected = !textDisabled && g.isTrackSelected(i)) {
-                    applyOverride(C.TRACK_TYPE_TEXT, g, i)
+                // Ignore embedded CEA CC in the trailing label — same filter as the picker.
+                if (type == C.TRACK_TYPE_TEXT && isEmbeddedCea(f)) continue
+                return f.label ?: langName(f.language) ?: "Track ${i + 1}"
+            }
+        }
+        return null
+    }
+
+    /** In-band CEA-608/708 often has no label/language (shows as "Subtitle 1") and
+     *  selecting it does nothing useful for anime softsubs — hide from the picker. */
+    private fun isEmbeddedCea(f: androidx.media3.common.Format): Boolean {
+        val mime = f.sampleMimeType ?: return false
+        return mime == MimeTypes.APPLICATION_CEA608 || mime == MimeTypes.APPLICATION_CEA708
+    }
+
+    private fun textTrackChoices(groups: List<Tracks.Group>): List<Pair<Tracks.Group, Int>> {
+        return groups
+            .filter { it.type == C.TRACK_TYPE_TEXT }
+            .flatMap { g -> (0 until g.length).map { g to it } }
+            .filter { (g, i) ->
+                g.isTrackSupported(i) && !isEmbeddedCea(g.getTrackFormat(i))
+            }
+    }
+
+    private fun subtitleTrackLabel(f: androidx.media3.common.Format, index: Int): String {
+        f.label?.takeIf { it.isNotBlank() }?.let { return it }
+        langName(f.language)?.let { return it }
+        return "Subtitle ${index + 1}"
+    }
+
+    private fun buildAvAudio() {
+        menuTitle("Audio")
+        val p = player ?: return
+        val groups = p.currentTracks.groups
+        if (availableCategories.size > 1) {
+            for (c in availableCategories) {
+                option(if (c == "dub") "Dub" else "Sub", selected = c == category, closeOnSelect = false) {
+                    switchCategory(c)
                 }
             }
         }
+        // Always list audio tracks — even a single track — so the submenu is never
+        // blank when Version isn't available (addTrackSection used to skip size<=1).
+        val gs = groups.filter { it.type == C.TRACK_TYPE_AUDIO && it.isSupported }
+        val tracks = gs.flatMap { g -> (0 until g.length).map { g to it } }
+        if (tracks.isEmpty()) {
+            option("Default", selected = true, closeOnSelect = false) {}
+        } else {
+            for ((g, i) in tracks) {
+                val f = g.getTrackFormat(i)
+                val label = f.label ?: langName(f.language) ?: "Audio ${i + 1}"
+                val group = g
+                val trackIndex = i
+                option(label, selected = g.isTrackSelected(i), closeOnSelect = false) {
+                    applyOverride(C.TRACK_TYPE_AUDIO, group, trackIndex)
+                    rebuildAvMenuDeferred()
+                }
+            }
+        }
+    }
 
-        // Online subtitle search (OpenSubtitles) — needs an API key. Shown even
-        // when the video has no subs, so you can add one.
+    private fun subtitleTrailingLabel(groups: List<Tracks.Group>, textDisabled: Boolean): String {
+        if (textUiForcedOff) return "Off"
+        textUiLabel?.let { return it }
+        val selectedSub = selectedTrackLabel(groups, C.TRACK_TYPE_TEXT)
+        // Exo often leaves TEXT enabled with nothing selected — that's Off, not "On".
+        return if (textDisabled || selectedSub == null) "Off" else selectedSub
+    }
+
+    private fun clearTextUiOverride() {
+        textUiForcedOff = false
+        textUiLabel = null
+    }
+
+    private fun buildAvSubs() {
+        menuTitle("Subtitles/CC")
+        val p = player ?: return
+        val groups = p.currentTracks.groups
+        val textTracks = textTrackChoices(groups)
+        val textDisabled = p.trackSelectionParameters.disabledTrackTypes.contains(C.TRACK_TYPE_TEXT)
+        val exoSelected = textTracks.any { (g, i) -> g.isTrackSelected(i) }
+        // Prefer optimistic UI state — Exo's isTrackSelected lags the menu rebuild.
+        val subsOff = when {
+            textUiForcedOff -> true
+            textUiLabel != null -> false
+            else -> textDisabled || !exoSelected
+        }
+        option("Off", selected = subsOff, closeOnSelect = false) {
+            textUiForcedOff = true
+            textUiLabel = "Off"
+            lastFocusLabel = "Off"
+            p.trackSelectionParameters = p.trackSelectionParameters.buildUpon()
+                .clearOverridesOfType(C.TRACK_TYPE_TEXT)
+                .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true).build()
+            rebuildAvMenuDeferred()
+        }
+        textTracks.forEachIndexed { index, (g, i) ->
+            val f = g.getTrackFormat(i)
+            val label = subtitleTrackLabel(f, index)
+            val group = g
+            val trackIndex = i
+            // Match by label — TrackGroup identity can churn after applyOverride.
+            val isSelected = when {
+                textUiForcedOff -> false
+                textUiLabel != null -> textUiLabel == label
+                else -> !subsOff && g.isTrackSelected(i)
+            }
+            option(label, selected = isSelected, closeOnSelect = false) {
+                textUiForcedOff = false
+                textUiLabel = label
+                lastFocusLabel = label
+                applyOverride(C.TRACK_TYPE_TEXT, group, trackIndex)
+                rebuildAvMenuDeferred()
+            }
+        }
         if (subtitleApiKeySet) {
-            if (textTracks.isEmpty()) sectionHeader("Subtitles")
-            option("Search online…", selected = false) { searchSubtitlesOnline() }
+            navRow("Search online…", null) { searchSubtitlesOnline() }
         }
+    }
 
-        // Subtitle size — live change + persisted (only when there are subs).
-        // Labels avoid "Normal" so they don't collide with the Speed section's
-        // "Normal" (option() restores focus by label). The checkmark snaps to the
-        // nearest bucket so an in-between persisted size still shows one.
-        if (textTracks.isNotEmpty()) {
-            sectionHeader("Subtitle size")
-            val sizes = listOf("Small" to 0.8f, "Medium" to 1.0f, "Large" to 1.3f)
-            val nearest = sizes.minByOrNull { kotlin.math.abs(it.second - subScale) }?.second
-            for ((sLabel, s) in sizes) {
-                option(sLabel, selected = s == nearest) {
-                    subScale = s
-                    playerView.subtitleView
-                        ?.setFractionalTextSize(SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * s)
-                    MainActivity.tvBridge?.invokeMethod(
-                        "setSubtitleScale", mapOf("scale" to s.toDouble()),
-                    )
+    private fun buildCaptionStyleRoot() {
+        menuTitle("Captions Styling")
+        navRow("Font Size", captionSizeLabel(subScale)) { pushAv(AvPage.SIZE) }
+        navRow("Text Color", captionColorLabel(subColorHex)) { pushAv(AvPage.COLOR) }
+        navRow("Edge Style", captionEdgeLabel(subOutlineId)) { pushAv(AvPage.EDGE) }
+        navRow("Background", captionBgLabel(subBgOpacity)) { pushAv(AvPage.BG) }
+        navRow("Font", if (subFontFamily.isEmpty()) "Default" else subFontFamily) { pushAv(AvPage.FONT) }
+        navRow("Position", captionPosLabel(subPositionPref)) { pushAv(AvPage.POS) }
+    }
+
+    private fun buildCaptionSize() {
+        menuTitle("Font Size")
+        val sizes = listOf("Small" to 0.8f, "Medium" to 1.0f, "Large" to 1.3f)
+        val nearest = sizes.minByOrNull { kotlin.math.abs(it.second - subScale) }?.second
+        for ((label, s) in sizes) {
+            option(label, selected = s == nearest, closeOnSelect = false) {
+                subScale = s
+                applySubtitleStyleLive()
+                MainActivity.tvBridge?.invokeMethod("setSubtitleScale", mapOf("scale" to s.toDouble()))
+                rebuildAvMenuDeferred()
+            }
+        }
+    }
+
+    private fun buildCaptionColor() {
+        menuTitle("Text Color")
+        val colors = listOf(
+            "#FFFFFFFF" to "White",
+            "#FFFF00FF" to "Yellow",
+            "#00E5FFFF" to "Cyan",
+            "#7CFC00FF" to "Green",
+            "#FF6B6BFF" to "Red",
+            "#000000FF" to "Black",
+        )
+        for ((hex, label) in colors) {
+            option(label, selected = subColorHex.equals(hex, ignoreCase = true), closeOnSelect = false) {
+                subColorHex = hex
+                subFg = parseColorHex(hex)
+                applySubtitleStyleLive()
+                MainActivity.tvBridge?.invokeMethod("setSubtitleColorHex", mapOf("hex" to hex))
+                rebuildAvMenuDeferred()
+            }
+        }
+    }
+
+    private fun buildCaptionEdge() {
+        menuTitle("Edge Style")
+        val edges = listOf(
+            "none" to ("None" to CaptionStyleCompat.EDGE_TYPE_NONE),
+            "outline" to ("Outline" to CaptionStyleCompat.EDGE_TYPE_OUTLINE),
+            "shadow" to ("Drop Shadow" to CaptionStyleCompat.EDGE_TYPE_DROP_SHADOW),
+            "raised" to ("Raised" to CaptionStyleCompat.EDGE_TYPE_RAISED),
+            "depressed" to ("Depressed" to CaptionStyleCompat.EDGE_TYPE_DEPRESSED),
+        )
+        for ((id, pair) in edges) {
+            val (label, type) = pair
+            option(label, selected = subEdgeType == type, closeOnSelect = false) {
+                subOutlineId = id
+                subEdgeType = type
+                applySubtitleStyleLive()
+                MainActivity.tvBridge?.invokeMethod("setSubtitleOutlineType", mapOf("type" to id))
+                rebuildAvMenuDeferred()
+            }
+        }
+    }
+
+    private fun buildCaptionBg() {
+        menuTitle("Background")
+        val bgs = listOf("Off" to 0f, "Light" to 0.25f, "Medium" to 0.5f, "Strong" to 0.75f)
+        val nearest = bgs.minByOrNull { kotlin.math.abs(it.second - subBgOpacity) }?.second
+        for ((label, o) in bgs) {
+            option(label, selected = o == nearest, closeOnSelect = false) {
+                subBgOpacity = o
+                subBgColor = ((o * 255).toInt() shl 24)
+                applySubtitleStyleLive()
+                MainActivity.tvBridge?.invokeMethod("setSubtitleBgOpacity", mapOf("opacity" to o.toDouble()))
+                rebuildAvMenuDeferred()
+            }
+        }
+    }
+
+    private fun buildCaptionFont() {
+        menuTitle("Font")
+        val fonts = listOf(
+            "" to "Default",
+            "Inter" to "Inter",
+            "Poppins" to "Poppins",
+            "Roboto" to "Roboto",
+            "Open Sans" to "Open Sans",
+            "Lato" to "Lato",
+            "Montserrat" to "Montserrat",
+            "Nunito" to "Nunito",
+            "Rubik" to "Rubik",
+            "Noto Sans" to "Noto Sans",
+            "Source Sans 3" to "Source Sans 3",
+        )
+        for ((family, label) in fonts) {
+            option(label, selected = subFontFamily == family, closeOnSelect = false) {
+                applyCaptionFont(family)
+            }
+        }
+    }
+
+    /** Persist + stage the bundled font, then re-apply CaptionStyleCompat. */
+    private fun applyCaptionFont(family: String) {
+        subFontFamily = family
+        MainActivity.tvBridge?.invokeMethod("setSubtitleFont", mapOf("font" to family))
+        if (family.isEmpty()) {
+            subFontPath = null
+            applySubtitleStyleLive()
+            rebuildAvMenuDeferred()
+            return
+        }
+        val bridge = MainActivity.tvBridge
+        if (bridge == null) {
+            applySubtitleStyleLive()
+            rebuildAvMenuDeferred()
+            return
+        }
+        bridge.invokeMethod(
+            "stageSubtitleFont",
+            mapOf("font" to family),
+            object : MethodChannel.Result {
+                override fun success(result: Any?) {
+                    val path = result as? String
+                    runOnUiThread {
+                        subFontPath = path
+                        applySubtitleStyleLive()
+                        rebuildAvMenuDeferred()
+                        if (path == null) toast("Could not load font")
+                    }
                 }
+                override fun error(code: String, msg: String?, details: Any?) {
+                    runOnUiThread {
+                        toast(msg ?: "Could not load font")
+                        rebuildAvMenuDeferred()
+                    }
+                }
+                override fun notImplemented() {
+                    runOnUiThread { rebuildAvMenuDeferred() }
+                }
+            },
+        )
+    }
+
+    private fun applySubtitleStyleLive() {
+        val tf = when {
+            !subFontPath.isNullOrBlank() ->
+                runCatching { android.graphics.Typeface.createFromFile(subFontPath) }.getOrNull()
+                    ?: android.graphics.Typeface.DEFAULT
+            else -> android.graphics.Typeface.DEFAULT
+        }
+        playerView.subtitleView?.apply {
+            setApplyEmbeddedStyles(false)
+            setApplyEmbeddedFontSizes(false)
+            setStyle(
+                CaptionStyleCompat(
+                    subFg,
+                    subBgColor,
+                    android.graphics.Color.TRANSPARENT,
+                    subEdgeType,
+                    android.graphics.Color.BLACK,
+                    tf,
+                ),
+            )
+            setFractionalTextSize(SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * subScale)
+            // Position is applied by remapping cue lines (see repositionCues) —
+            // bottom padding alone is ignored when cues already set a line.
+            setBottomPaddingFraction(0.02f)
+            invalidate()
+        }
+        // Re-apply current cues so a Position change takes effect immediately.
+        player?.currentCues?.let { playerView.subtitleView?.setCues(repositionCues(it.cues)) }
+    }
+
+    /**
+     * Force each cue onto the user's vertical preference (0=top … 100=bottom).
+     * Media3's [SubtitleView.setBottomPaddingFraction] only shifts cues that
+     * leave line unset — most VTT/SRT/ASS cues set their own line, so without
+     * this remapping Low/Middle/High look identical.
+     */
+    private fun repositionCues(cues: List<Cue>): List<Cue> {
+        if (cues.isEmpty()) return cues
+        val line = subPositionPref.coerceIn(0, 100) / 100f
+        return cues.map { cue ->
+            cue.buildUpon()
+                .setLine(line, Cue.LINE_TYPE_FRACTION)
+                .setLineAnchor(Cue.ANCHOR_TYPE_END)
+                .build()
+        }
+    }
+
+    private fun buildCaptionPos() {
+        menuTitle("Position")
+        val positions = listOf("Low" to 95, "Middle" to 70, "High" to 40)
+        val nearest = positions.minByOrNull { kotlin.math.abs(it.second - subPositionPref) }?.second
+        for ((label, pos) in positions) {
+            option(label, selected = pos == nearest, closeOnSelect = false) {
+                subPositionPref = pos
+                applySubtitleStyleLive()
+                MainActivity.tvBridge?.invokeMethod("setSubtitlePosition", mapOf("position" to pos))
+                rebuildAvMenuDeferred()
             }
         }
+    }
 
-        // Playback speed.
-        sectionHeader("Speed")
-        for (s in listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)) {
-            option(if (s == 1.0f) "Normal" else "${s}×", selected = speed == s) {
-                speed = s
-                player?.playbackParameters = PlaybackParameters(s)
-            }
-        }
-
-        // Volume boost.
-        sectionHeader("Volume")
+    private fun buildAvVolume() {
+        menuTitle("Volume")
         for (v in listOf(100, 125, 150, 175, 200)) {
-            option("$v%", selected = volumePercent == v) { applyVolume(v) }
+            option(if (v == 100) "100% (normal)" else "$v%", selected = volumePercent == v, closeOnSelect = false) {
+                applyVolume(v)
+                rebuildAvMenuDeferred()
+            }
+        }
+    }
+
+    private fun captionSizeLabel(scale: Float): String {
+        val sizes = listOf("Small" to 0.8f, "Medium" to 1.0f, "Large" to 1.3f)
+        return sizes.minByOrNull { kotlin.math.abs(it.second - scale) }?.first ?: "Medium"
+    }
+
+    private fun captionColorLabel(hex: String): String {
+        val colors = listOf(
+            "#FFFFFFFF" to "White", "#FFFF00FF" to "Yellow", "#00E5FFFF" to "Cyan",
+            "#7CFC00FF" to "Green", "#FF6B6BFF" to "Red", "#000000FF" to "Black",
+        )
+        return colors.firstOrNull { it.first.equals(hex, ignoreCase = true) }?.second ?: "Custom"
+    }
+
+    private fun captionEdgeLabel(id: String): String = when (id) {
+        "none" -> "None"
+        "shadow" -> "Drop Shadow"
+        "raised" -> "Raised"
+        "depressed" -> "Depressed"
+        else -> "Outline"
+    }
+
+    private fun captionBgLabel(opacity: Float): String {
+        val bgs = listOf("Off" to 0f, "Light" to 0.25f, "Medium" to 0.5f, "Strong" to 0.75f)
+        return bgs.minByOrNull { kotlin.math.abs(it.second - opacity) }?.first ?: "Off"
+    }
+
+    private fun captionPosLabel(pos: Int): String {
+        val positions = listOf("Low" to 95, "Middle" to 70, "High" to 40)
+        return positions.minByOrNull { kotlin.math.abs(it.second - pos) }?.first ?: "Low"
+    }
+
+    private fun parseColorHex(hex: String): Int {
+        var h = hex.removePrefix("#").trim()
+        if (h.length == 6) h = h + "FF"
+        if (h.length != 8) return android.graphics.Color.WHITE
+        return try {
+            val rgb = h.substring(0, 6)
+            val a = h.substring(6, 8)
+            android.graphics.Color.parseColor("#$a$rgb")
+        } catch (_: Exception) {
+            android.graphics.Color.WHITE
         }
     }
 
@@ -926,15 +1380,20 @@ class TvPlayerActivity : Activity() {
         title: String,
         groups: List<Tracks.Group>,
         type: Int,
+        closeOnSelect: Boolean = true,
         label: (androidx.media3.common.Format, Int) -> String,
     ) {
         val gs = groups.filter { it.type == type && it.isSupported }
         val tracks = gs.flatMap { g -> (0 until g.length).map { g to it } }
         if (tracks.size <= 1) return
-        sectionHeader(title)
+        // When already under a page title (Audio), skip the redundant section header.
+        if (closeOnSelect) sectionHeader(title)
         for ((g, i) in tracks) {
-            option(label(g.getTrackFormat(i), i), selected = g.isTrackSelected(i)) {
-                applyOverride(type, g, i)
+            val group = g
+            val trackIndex = i
+            option(label(g.getTrackFormat(i), i), selected = g.isTrackSelected(i), closeOnSelect = closeOnSelect) {
+                applyOverride(type, group, trackIndex)
+                if (!closeOnSelect) rebuildAvMenuDeferred()
             }
         }
     }
@@ -1043,37 +1502,6 @@ class TvPlayerActivity : Activity() {
         } catch (_: Exception) { /* effect unavailable on this device */ }
     }
 
-    /** Style side-loaded + embedded subtitles from the saved prefs: scale, colour,
-     *  optional background, black outline (readable on TV over any scene). */
-    private fun applySubtitleStyle() {
-        // Values are pre-computed by captionStyleFromPrefs (Dart), identical to
-        // the Flutter PlatformView player — colour, box, outline, position, font.
-        // subScale is a field so an in-player size change survives re-styling.
-        val fg = intent.getIntExtra(EXTRA_SUB_FG, android.graphics.Color.WHITE)
-        val bg = intent.getIntExtra(EXTRA_SUB_BG_COLOR, android.graphics.Color.TRANSPARENT)
-        val edge = intent.getBooleanExtra(EXTRA_SUB_EDGE, true)
-        val pos = intent.getFloatExtra(EXTRA_SUB_POS, 0.05f)
-        val tf = intent.getStringExtra(EXTRA_SUB_FONT)
-            ?.let { runCatching { android.graphics.Typeface.createFromFile(it) }.getOrNull() }
-        playerView.subtitleView?.apply {
-            setApplyEmbeddedStyles(false)
-            setApplyEmbeddedFontSizes(false)
-            setStyle(
-                CaptionStyleCompat(
-                    fg,
-                    bg,
-                    android.graphics.Color.TRANSPARENT,
-                    if (edge) CaptionStyleCompat.EDGE_TYPE_OUTLINE
-                    else CaptionStyleCompat.EDGE_TYPE_NONE,
-                    android.graphics.Color.BLACK,
-                    tf,
-                ),
-            )
-            setFractionalTextSize(SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * subScale)
-            setBottomPaddingFraction(pos)
-        }
-    }
-
     private fun langName(code: String?): String? {
         if (code.isNullOrBlank() || code == "und") return null
         return try {
@@ -1093,7 +1521,56 @@ class TvPlayerActivity : Activity() {
         })
     }
 
-    private fun option(label: String, selected: Boolean, onSelect: () -> Unit) {
+    /** Summary / nav row: label left, optional trailing value right, no check. */
+    private fun navRow(label: String, trailing: String?, onSelect: () -> Unit) {
+        val row = android.widget.LinearLayout(this).apply {
+            orientation = android.widget.LinearLayout.HORIZONTAL
+            isFocusable = true
+            isFocusableInTouchMode = true
+            setPadding(dp(16), dp(14), dp(16), dp(14))
+            background = pillBg(0x00000000)
+            addView(TextView(this@TvPlayerActivity).apply {
+                text = label
+                setTextColor(android.graphics.Color.WHITE)
+                textSize = 16.5f
+                layoutParams = android.widget.LinearLayout.LayoutParams(
+                    0, android.widget.LinearLayout.LayoutParams.WRAP_CONTENT, 1f,
+                )
+            })
+            if (trailing != null) {
+                addView(TextView(this@TvPlayerActivity).apply {
+                    text = trailing
+                    setTextColor(0x8CFFFFFF.toInt())
+                    textSize = 15f
+                    tag = "trailing"
+                })
+            }
+            onFocusChangeListener = View.OnFocusChangeListener { v, has ->
+                v.background = pillBg(if (has) accent else 0x00000000)
+                val trail = (v as android.widget.LinearLayout).findViewWithTag<TextView>("trailing")
+                trail?.setTextColor(if (has) android.graphics.Color.WHITE else 0x8CFFFFFF.toInt())
+            }
+            bindSingleTapActivate {
+                lastFocusLabel = label
+                onSelect()
+            }
+        }
+        if (label == lastFocusLabel) focusTarget = row
+        menuContent.addView(
+            row,
+            android.widget.LinearLayout.LayoutParams(
+                android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+            ),
+        )
+    }
+
+    private fun option(
+        label: String,
+        selected: Boolean,
+        closeOnSelect: Boolean = true,
+        onSelect: () -> Unit,
+    ) {
         val row = TextView(this).apply {
             text = (if (selected) "✓   " else "     ") + label
             setTextColor(if (selected) android.graphics.Color.WHITE else 0xFFB6B6C0.toInt())
@@ -1109,11 +1586,10 @@ class TvPlayerActivity : Activity() {
                     else if (selected) android.graphics.Color.WHITE else 0xFFB6B6C0.toInt()
                 )
             }
-            // Single-tap on touchscreens: highlight + select (not focus-then-click).
             bindSingleTapActivate {
                 lastFocusLabel = label
                 onSelect()
-                closeMenu()
+                if (closeOnSelect) closeMenu()
             }
         }
         if (selected && firstSelectedRow == null) firstSelectedRow = row
@@ -1155,6 +1631,7 @@ class TvPlayerActivity : Activity() {
         btnAudioSubs = findViewById(R.id.btn_audio_subs)
         btnNext = findViewById(R.id.btn_next)
         btnMegaskip = findViewById(R.id.btn_megaskip)
+        btnSpeed = findViewById(R.id.btn_speed)
         fillerBadge = findViewById(R.id.filler_badge)
         // MegaSkip pill: label + visibility from the megaSkip prefs (launch extras).
         megaSkipSecs = intent.getIntExtra(EXTRA_MEGASKIP_SECS, 85)
@@ -1199,7 +1676,7 @@ class TvPlayerActivity : Activity() {
             }
         })
 
-        for (b in listOf(btnEpisodes, btnQuality, btnSources, btnAudioSubs, btnNext, btnMegaskip)) {
+        for (b in listOf(btnEpisodes, btnQuality, btnSources, btnAudioSubs, btnNext, btnMegaskip, btnSpeed)) {
             // Focusable even in touch mode so requestFocus() works on emulators
             // (real TVs are always in D-pad/non-touch mode anyway).
             applyPillFocus(b, false)
@@ -1209,7 +1686,7 @@ class TvPlayerActivity : Activity() {
                     // Keep zone in sync for touch focus (D-pad uses enterZone).
                     focusZone = when (v.id) {
                         R.id.btn_quality, R.id.btn_sources, R.id.btn_audio_subs -> 1
-                        else -> 2 // episodes / next / megaskip bottom row
+                        else -> 2 // episodes / next / megaskip / speed bottom row
                     }
                     cancelAutoHide()
                 }
@@ -1224,6 +1701,8 @@ class TvPlayerActivity : Activity() {
         btnAudioSubs.bindSingleTapActivate { openAvMenu() }
         btnNext.bindSingleTapActivate { loadEpisode(nextAutoplayIndex()) }
         btnMegaskip.bindSingleTapActivate { seekBy(megaSkipSecs * 1000L) }
+        btnSpeed.bindSingleTapActivate { openSpeedMenu() }
+        updateSpeedPillLabel()
 
         applyPillFocus(skipButton, false)
         skipButton.onFocusChangeListener =
@@ -1439,6 +1918,31 @@ class TvPlayerActivity : Activity() {
         bumpControls()
     }
 
+    private fun updateSpeedPillLabel() {
+        btnSpeed.text = if (kotlin.math.abs(speed - 1f) < 0.001f) "1×" else "${speed}×"
+    }
+
+    /** Playback speed — same right-side panel as Quality / Audio & Subs. */
+    private fun openSpeedMenu() = showMenu(btnSpeed) { buildSpeedMenu() }
+
+    private fun buildSpeedMenu() {
+        menuTitle("Speed")
+        val speeds = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 2.0f)
+        for (s in speeds) {
+            option(
+                if (s == 1.0f) "Normal" else "${s}×",
+                selected = kotlin.math.abs(speed - s) < 0.001f,
+            ) {
+                speed = s
+                player?.playbackParameters = PlaybackParameters(s)
+                updateSpeedPillLabel()
+                MainActivity.tvBridge?.invokeMethod(
+                    "setDefaultSpeed", mapOf("speed" to s.toDouble()),
+                )
+            }
+        }
+    }
+
     // ── Button-row focus (zone 1 = top-right actions, zone 2 = bottom) ────────
     private fun enterZone(zone: Int) {
         showControls()
@@ -1642,6 +2146,7 @@ class TvPlayerActivity : Activity() {
     // close an open menu, else hide the controls, else exit the player.
     private fun handleBack() {
         when {
+            menuPanel.visibility == View.VISIBLE && avMenuActive && avStack.isNotEmpty() -> popAvOrClose()
             menuPanel.visibility == View.VISIBLE -> closeMenu()
             controls.visibility == View.VISIBLE -> {
                 cancelAutoHide()

--- a/android/app/src/main/res/drawable/ic_tv_speed.xml
+++ b/android/app/src/main/res/drawable/ic_tv_speed.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Icons "speed" — same family as the other ic_tv_* pills. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="22dp"
+    android:height="22dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20.38,8.57l-1.23,1.85a8,8 0,0 1,-0.22 7.58H5.07A8,8 0,0 1,15.58 6.85l1.85,-1.23A10,10 0,0 0,3.35 19a2,2 0,0 0,1.72 1h13.85a2,2 0,0 0,1.74 -1,10 10,0 0,0 -0.27,-10.44zM10.59,15.41a2,2 0,0 0,2.83 0l5.66,-8.49 -8.49,5.66a2,2 0,0 0,0 2.83z"/>
+</vector>

--- a/android/app/src/main/res/layout/tv_player.xml
+++ b/android/app/src/main/res/layout/tv_player.xml
@@ -2,307 +2,89 @@
 <!-- Fully-native TV player screen: an ExoPlayer PlayerView (SurfaceView, direct
      to the window — no Flutter platform view) with a custom Netflix-style
      control overlay the Activity drives. useController=false: we draw and key-
-     handle everything ourselves so OK=play/pause, ◀▶=seek, ▼=button row, and
-     hold-OK=2× behave exactly as designed. -->
+     handle everything ourselves so OK=play/pause, ◀▶=seek, ▼=button row, and hold-OK=2× behave exactly as designed. -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/player_root"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="#000000"
-    android:clipChildren="false"
-    android:clipToPadding="false"
-    android:focusable="true"
-    android:focusableInTouchMode="true">
+    xmlns:tools="http://schemas.android.com/tools" android:id="@+id/player_root" android:layout_width="match_parent" android:layout_height="match_parent" android:background="#000000" android:clipChildren="false" android:clipToPadding="false" android:focusable="true" android:focusableInTouchMode="true">
 
-    <androidx.media3.ui.PlayerView
-        android:id="@+id/player_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:surface_type="surface_view"
-        app:resize_mode="fit"
-        app:use_controller="false" />
+    <androidx.media3.ui.PlayerView android:id="@+id/player_view" android:layout_width="match_parent" android:layout_height="match_parent" app:surface_type="surface_view" app:resize_mode="fit" app:use_controller="false" />
 
     <!-- Buffering / episode-resolve spinner (accent-tinted in code). -->
-    <ProgressBar
-        android:id="@+id/loading"
-        style="?android:attr/progressBarStyleLarge"
-        android:layout_width="46dp"
-        android:layout_height="46dp"
-        android:layout_gravity="center"
-        android:indeterminate="true"
-        android:visibility="gone" />
+    <ProgressBar android:id="@+id/loading" style="?android:attr/progressBarStyleLarge" android:layout_width="46dp" android:layout_height="46dp" android:layout_gravity="center" android:indeterminate="true" android:visibility="gone" />
 
     <!-- Skip intro/ending pill (AniSkip). Shown during the interval; press OK to
          jump to its end. Sits above the control row, independent of it. -->
-    <TextView
-        android:id="@+id/skip_button"
-        style="@style/TvPillButton"
-        android:layout_gravity="bottom|end"
-        android:layout_marginEnd="44dp"
-        android:layout_marginBottom="120dp"
-        android:drawableStart="@drawable/ic_tv_next"
-        android:text="Skip Intro"
-        android:visibility="gone"
-        tools:ignore="HardcodedText" />
+    <TextView android:id="@+id/skip_button" style="@style/TvPillButton" android:layout_gravity="bottom|end" android:layout_marginEnd="44dp" android:layout_marginBottom="120dp" android:drawableStart="@drawable/ic_tv_next" android:text="Skip Intro" android:visibility="gone" tools:ignore="HardcodedText" />
 
-    <!-- Right-side options menu (Server / Quality / Audio / Sub-Dub / Subtitles /
-         Speed / Volume). Populated + driven by the Activity; native focus handles
-         D-pad while it's open. -->
-    <ScrollView
-        android:id="@+id/menu_panel"
-        android:layout_width="452dp"
-        android:layout_height="match_parent"
-        android:layout_gravity="end"
-        android:background="#F00C0C10"
-        android:paddingHorizontal="30dp"
-        android:paddingVertical="34dp"
-        android:scrollbars="none"
-        android:visibility="gone">
+    <!-- Right-side options menu (Settings / Episodes / Speed / …).
+         Populated + driven by the Activity; native focus handles D-pad. -->
+    <ScrollView android:id="@+id/menu_panel" android:layout_width="452dp" android:layout_height="match_parent" android:layout_gravity="end" android:background="#F00C0C10" android:paddingHorizontal="30dp" android:paddingVertical="34dp" android:scrollbars="none" android:visibility="gone">
 
-        <LinearLayout
-            android:id="@+id/menu_content"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical" />
+        <LinearLayout android:id="@+id/menu_content" android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical" />
     </ScrollView>
 
     <!-- Controls overlay — toggled GONE/VISIBLE by the Activity, auto-hides. -->
-    <FrameLayout
-        android:id="@+id/controls"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:visibility="gone">
+    <FrameLayout android:id="@+id/controls" android:layout_width="match_parent" android:layout_height="match_parent" android:clipChildren="false" android:clipToPadding="false" android:visibility="gone">
 
         <!-- Top scrim + title / episode label -->
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="150dp"
-            android:layout_gravity="top"
-            android:background="@drawable/tv_scrim_top" />
+        <View android:layout_width="match_parent" android:layout_height="150dp" android:layout_gravity="top" android:background="@drawable/tv_scrim_top" />
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="top|start"
-            android:layout_marginStart="44dp"
-            android:layout_marginTop="30dp"
-            android:orientation="vertical">
+        <LinearLayout android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="top|start" android:layout_marginStart="44dp" android:layout_marginTop="30dp" android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:maxWidth="760dp"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:textColor="#FFFFFF"
-                android:textSize="24sp"
-                android:textStyle="bold"
-                tools:ignore="HardcodedText" />
+            <TextView android:id="@+id/title" android:layout_width="wrap_content" android:layout_height="wrap_content" android:maxWidth="760dp" android:ellipsize="end" android:maxLines="1" android:textColor="#FFFFFF" android:textSize="24sp" android:textStyle="bold" tools:ignore="HardcodedText" />
 
-            <TextView
-                android:id="@+id/episode_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:textColor="#CCFFFFFF"
-                android:textSize="15sp" />
+            <TextView android:id="@+id/episode_label" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="2dp" android:textColor="#CCFFFFFF" android:textSize="15sp" />
 
-            <TextView
-                android:id="@+id/filler_badge"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                android:background="@drawable/tv_filler_badge"
-                android:paddingLeft="8dp"
-                android:paddingRight="8dp"
-                android:paddingTop="2dp"
-                android:paddingBottom="2dp"
-                android:text="FILLER"
-                android:textColor="#FFFF4D5E"
-                android:textSize="11sp"
-                android:textStyle="bold"
-                android:visibility="gone"
-                tools:ignore="HardcodedText" />
+            <TextView android:id="@+id/filler_badge" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="6dp" android:background="@drawable/tv_filler_badge" android:paddingLeft="8dp" android:paddingRight="8dp" android:paddingTop="2dp" android:paddingBottom="2dp" android:text="FILLER" android:textColor="#FFFF4D5E" android:textSize="11sp" android:textStyle="bold" android:visibility="gone" tools:ignore="HardcodedText" />
         </LinearLayout>
 
         <!-- Top-right header quick actions (JioHotstar-style small buttons) -->
-        <LinearLayout
-            android:id="@+id/top_row"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="top|end"
-            android:layout_marginEnd="44dp"
-            android:layout_marginTop="28dp"
-            android:clipChildren="false"
-            android:clipToPadding="false"
-            android:orientation="horizontal">
+        <LinearLayout android:id="@+id/top_row" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="top|end" android:layout_marginEnd="44dp" android:layout_marginTop="28dp" android:clipChildren="false" android:clipToPadding="false" android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/btn_quality"
-                style="@style/TvPillButtonSmall"
-                android:drawableStart="@drawable/ic_tv_quality"
-                android:text="Quality"
-                tools:ignore="HardcodedText" />
+            <TextView android:id="@+id/btn_quality" style="@style/TvPillButtonSmall" android:drawableStart="@drawable/ic_tv_quality" android:text="Quality" tools:ignore="HardcodedText" />
 
-            <TextView
-                android:id="@+id/btn_sources"
-                style="@style/TvPillButtonSmall"
-                android:layout_marginStart="10dp"
-                android:drawableStart="@drawable/ic_tv_sources"
-                android:text="Sources"
-                tools:ignore="HardcodedText" />
+            <TextView android:id="@+id/btn_sources" style="@style/TvPillButtonSmall" android:layout_marginStart="10dp" android:drawableStart="@drawable/ic_tv_sources" android:text="Sources" tools:ignore="HardcodedText" />
 
-            <TextView
-                android:id="@+id/btn_audio_subs"
-                style="@style/TvPillButtonSmall"
-                android:layout_marginStart="10dp"
-                android:drawableStart="@drawable/ic_tv_captions"
-                android:text="Audio &amp; Subs"
-                tools:ignore="HardcodedText" />
+            <TextView android:id="@+id/btn_audio_subs" style="@style/TvPillButtonSmall" android:layout_marginStart="10dp" android:drawableStart="@drawable/ic_tv_captions" android:text="Audio &amp; Subs" tools:ignore="HardcodedText" />
         </LinearLayout>
 
         <!-- Center play/pause indicator (shown while paused) -->
-        <ImageView
-            android:id="@+id/center_icon"
-            android:layout_width="86dp"
-            android:layout_height="86dp"
-            android:layout_gravity="center"
-            android:background="@drawable/tv_center_circle"
-            android:padding="21dp"
-            android:src="@drawable/ic_tv_play"
-            android:visibility="gone"
-            tools:ignore="ContentDescription" />
+        <ImageView android:id="@+id/center_icon" android:layout_width="86dp" android:layout_height="86dp" android:layout_gravity="center" android:background="@drawable/tv_center_circle" android:padding="21dp" android:src="@drawable/ic_tv_play" android:visibility="gone" tools:ignore="ContentDescription" />
 
         <!-- Transient seek indicator (e.g. "+10s") -->
-        <TextView
-            android:id="@+id/seek_indicator"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:background="#99000000"
-            android:paddingHorizontal="18dp"
-            android:paddingVertical="10dp"
-            android:textColor="#FFFFFF"
-            android:textSize="20sp"
-            android:textStyle="bold"
-            android:visibility="gone" />
+        <TextView android:id="@+id/seek_indicator" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="center" android:background="#99000000" android:paddingHorizontal="18dp" android:paddingVertical="10dp" android:textColor="#FFFFFF" android:textSize="20sp" android:textStyle="bold" android:visibility="gone" />
 
         <!-- Speed badge shown while holding OK (2×) -->
-        <TextView
-            android:id="@+id/speed_badge"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="top|center_horizontal"
-            android:layout_marginTop="40dp"
-            android:background="#CC000000"
-            android:paddingHorizontal="16dp"
-            android:paddingVertical="8dp"
-            android:text="2× speed"
-            android:textColor="#FFFFFF"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            android:visibility="gone"
-            tools:ignore="HardcodedText" />
+        <TextView android:id="@+id/speed_badge" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="top|center_horizontal" android:layout_marginTop="40dp" android:background="#CC000000" android:paddingHorizontal="16dp" android:paddingVertical="8dp" android:text="2× speed" android:textColor="#FFFFFF" android:textSize="16sp" android:textStyle="bold" android:visibility="gone" tools:ignore="HardcodedText" />
 
         <!-- Bottom scrim -->
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="220dp"
-            android:layout_gravity="bottom"
-            android:background="@drawable/tv_scrim_bottom" />
+        <View android:layout_width="match_parent" android:layout_height="220dp" android:layout_gravity="bottom" android:background="@drawable/tv_scrim_bottom" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom"
-            android:layout_marginHorizontal="44dp"
-            android:layout_marginBottom="34dp"
-            android:clipChildren="false"
-            android:clipToPadding="false"
-            android:orientation="vertical">
+        <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_gravity="bottom" android:layout_marginHorizontal="44dp" android:layout_marginBottom="34dp" android:clipChildren="false" android:clipToPadding="false" android:orientation="vertical">
 
             <!-- Seek bar row -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:orientation="horizontal">
+            <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:gravity="center_vertical" android:orientation="horizontal">
 
-                <TextView
-                    android:id="@+id/position"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:minWidth="66dp"
-                    android:text="0:00"
-                    android:textColor="#FFFFFF"
-                    android:textSize="15sp"
-                    tools:ignore="HardcodedText" />
+                <TextView android:id="@+id/position" android:layout_width="wrap_content" android:layout_height="wrap_content" android:minWidth="66dp" android:text="0:00" android:textColor="#FFFFFF" android:textSize="15sp" tools:ignore="HardcodedText" />
 
-                <androidx.media3.ui.DefaultTimeBar
-                    android:id="@+id/time_bar"
-                    android:layout_width="0dp"
-                    android:layout_height="30dp"
-                    android:layout_weight="1"
-                    android:layout_marginHorizontal="16dp"
-                    app:bar_height="5dp"
-                    app:scrubber_enabled_size="17dp"
-                    app:scrubber_dragged_size="21dp"
-                    app:touch_target_height="30dp"
-                    app:unplayed_color="#40FFFFFF"
-                    app:buffered_color="#66FFFFFF" />
+                <androidx.media3.ui.DefaultTimeBar android:id="@+id/time_bar" android:layout_width="0dp" android:layout_height="30dp" android:layout_weight="1" android:layout_marginHorizontal="16dp" app:bar_height="5dp" app:scrubber_enabled_size="17dp" app:scrubber_dragged_size="21dp" app:touch_target_height="30dp" app:unplayed_color="#40FFFFFF" app:buffered_color="#66FFFFFF" />
 
-                <TextView
-                    android:id="@+id/duration"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:minWidth="66dp"
-                    android:gravity="end"
-                    android:text="0:00"
-                    android:textColor="#CCFFFFFF"
-                    android:textSize="15sp"
-                    tools:ignore="HardcodedText" />
+                <TextView android:id="@+id/duration" android:layout_width="wrap_content" android:layout_height="wrap_content" android:minWidth="66dp" android:gravity="end" android:text="0:00" android:textColor="#CCFFFFFF" android:textSize="15sp" tools:ignore="HardcodedText" />
             </LinearLayout>
 
             <!-- Bottom quick actions (small) -->
-            <LinearLayout
-                android:id="@+id/button_row"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:clipChildren="false"
-                android:clipToPadding="false"
-                android:orientation="horizontal">
+            <LinearLayout android:id="@+id/button_row" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp" android:clipChildren="false" android:clipToPadding="false" android:orientation="horizontal">
 
-                <TextView
-                    android:id="@+id/btn_episodes"
-                    style="@style/TvPillButtonSmall"
-                    android:drawableStart="@drawable/ic_tv_episodes"
-                    android:text="Episodes"
-                    tools:ignore="HardcodedText" />
+                <TextView android:id="@+id/btn_episodes" style="@style/TvPillButtonSmall" android:drawableStart="@drawable/ic_tv_episodes" android:text="Episodes" tools:ignore="HardcodedText" />
 
-                <TextView
-                    android:id="@+id/btn_next"
-                    style="@style/TvPillButtonSmall"
-                    android:layout_marginStart="10dp"
-                    android:drawableStart="@drawable/ic_tv_next"
-                    android:text="Next Episode"
-                    tools:ignore="HardcodedText" />
+                <TextView android:id="@+id/btn_next" style="@style/TvPillButtonSmall" android:layout_marginStart="10dp" android:drawableStart="@drawable/ic_tv_next" android:text="Next Episode" tools:ignore="HardcodedText" />
 
                 <!-- MegaSkip: manual jump-forward N seconds (Aniyomi-style).
                      Text + visibility set in code from the megaSkip prefs. -->
-                <TextView
-                    android:id="@+id/btn_megaskip"
-                    style="@style/TvPillButtonSmall"
-                    android:layout_marginStart="10dp"
-                    android:drawableStart="@drawable/ic_tv_next"
-                    android:text="+85s"
-                    android:visibility="gone"
-                    tools:ignore="HardcodedText" />
+                <!-- Speed pill + MegaSkip sit together on the bottom row. -->
+                <TextView android:id="@+id/btn_speed" style="@style/TvPillButtonSmall" android:layout_marginStart="10dp" android:drawableStart="@drawable/ic_tv_speed" android:text="1×" tools:ignore="HardcodedText" />
+
+                <TextView android:id="@+id/btn_megaskip" style="@style/TvPillButtonSmall" android:layout_marginStart="10dp" android:drawableStart="@drawable/ic_tv_next" android:text="+85s" android:visibility="gone" tools:ignore="HardcodedText" />
             </LinearLayout>
         </LinearLayout>
     </FrameLayout>

--- a/lib/core/playback/subtitle_font_stage.dart
+++ b/lib/core/playback/subtitle_font_stage.dart
@@ -3,27 +3,40 @@ import 'dart:io';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:path_provider/path_provider.dart';
 
-import 'tv_track_helpers.dart' show subtitleFontAsset;
+import 'tv_track_helpers.dart' show subtitleFontAsset, subtitleFontFileName;
 
-/// Copies the chosen bundled subtitle font to app-support once, so the native
-/// TV players can `Typeface.createFromFile` it. Returns null for the default
-/// family ('') or an unknown one. Shared by both TV players (the Flutter
-/// PlatformView player and the fully-native TvPlayerActivity) so the staging
-/// path is defined in exactly one place.
+/// Copies / locates a subtitle font under `<appSupport>/sub_fonts/` so native
+/// TV players can `Typeface.createFromFile` it.
+///
+/// Callers must [SubtitleFontService.ensure] download-on-demand families first.
+/// Bundled APK fonts (Inter, Noto Sans) are copied from assets here.
+/// Returns null for Default ('') or when the file is missing.
 Future<String?> stageSubtitleFont(String family) async {
   if (family.isEmpty) return null;
+
+  final dir = Directory(
+    '${(await getApplicationSupportDirectory()).path}/sub_fonts',
+  );
+  if (!dir.existsSync()) dir.createSync(recursive: true);
+
   final asset = subtitleFontAsset(family);
-  if (asset == null) return null;
-  try {
-    final dir = await getApplicationSupportDirectory();
-    final out = File('${dir.path}/sub_fonts/${asset.split('/').last}');
-    if (!await out.exists()) {
-      await out.parent.create(recursive: true);
-      final bytes = await rootBundle.load(asset);
-      await out.writeAsBytes(bytes.buffer.asUint8List());
+  if (asset != null) {
+    // Bundled in the APK — copy from assets once.
+    try {
+      final out = File('${dir.path}/${asset.split('/').last}');
+      if (!await out.exists()) {
+        final bytes = await rootBundle.load(asset);
+        await out.writeAsBytes(bytes.buffer.asUint8List(), flush: true);
+      }
+      return out.path;
+    } catch (_) {
+      return null;
     }
-    return out.path;
-  } catch (_) {
-    return null;
   }
+
+  // Download-on-demand: already ensured into this folder by the caller.
+  final fname = subtitleFontFileName(family);
+  if (fname == null) return null;
+  final f = File('${dir.path}/$fname');
+  return f.existsSync() ? f.path : null;
 }

--- a/lib/core/playback/tv_track_helpers.dart
+++ b/lib/core/playback/tv_track_helpers.dart
@@ -52,20 +52,132 @@ class TvSubDecision {
   final Language? language; // for download
 }
 
+/// Media3 [CaptionStyleCompat] edge-type constants.
+const int kTvEdgeNone = 0;
+const int kTvEdgeOutline = 1;
+const int kTvEdgeDropShadow = 2;
+const int kTvEdgeRaised = 3;
+const int kTvEdgeDepressed = 4;
+
+/// TV Captions Styling edge picker: (pref id, label, Media3 edge type).
+const List<(String, String, int)> kTvCaptionEdgeTypes = [
+  ('none', 'None', kTvEdgeNone),
+  ('outline', 'Outline', kTvEdgeOutline),
+  ('shadow', 'Drop Shadow', kTvEdgeDropShadow),
+  ('raised', 'Raised', kTvEdgeRaised),
+  ('depressed', 'Depressed', kTvEdgeDepressed),
+];
+
+/// Text-colour swatches for TV Captions Styling (#RRGGBBAA → label).
+const List<(String, String)> kTvCaptionColors = [
+  ('#FFFFFFFF', 'White'),
+  ('#FFFF00FF', 'Yellow'),
+  ('#00E5FFFF', 'Cyan'),
+  ('#7CFC00FF', 'Green'),
+  ('#FF6B6BFF', 'Red'),
+  ('#000000FF', 'Black'),
+];
+
+/// Font size buckets for TV Captions Styling.
+const List<(String, double)> kTvCaptionSizes = [
+  ('Small', 0.8),
+  ('Medium', 1.0),
+  ('Large', 1.3),
+];
+
+/// Background opacity buckets for TV Captions Styling.
+const List<(String, double)> kTvCaptionBackgrounds = [
+  ('Off', 0.0),
+  ('Light', 0.25),
+  ('Medium', 0.5),
+  ('Strong', 0.75),
+];
+
+/// Vertical position buckets (PlaybackPrefs subtitlePosition 0–100).
+const List<(String, int)> kTvCaptionPositions = [
+  ('Low', 95),
+  ('Middle', 70),
+  ('High', 40),
+];
+
+/// Maps a [PlaybackPrefs.subtitleOutlineType] id to a Media3 edge type.
+/// Phone-only presets (`soft` / `glow` / `bold`) fall back to outline.
+int tvEdgeTypeFromOutlinePref(String outlineType) {
+  switch (outlineType) {
+    case 'none':
+      return kTvEdgeNone;
+    case 'shadow':
+      return kTvEdgeDropShadow;
+    case 'raised':
+      return kTvEdgeRaised;
+    case 'depressed':
+      return kTvEdgeDepressed;
+    case 'outline':
+    case 'soft':
+    case 'glow':
+    case 'bold':
+    default:
+      return kTvEdgeOutline;
+  }
+}
+
+String tvCaptionSizeLabel(double scale) {
+  final nearest = kTvCaptionSizes.reduce(
+    (a, b) => (a.$2 - scale).abs() <= (b.$2 - scale).abs() ? a : b,
+  );
+  return nearest.$1;
+}
+
+String tvCaptionColorLabel(String colorHex) {
+  final want = colorHex.toUpperCase();
+  for (final (hex, label) in kTvCaptionColors) {
+    if (hex == want) return label;
+  }
+  return 'Custom';
+}
+
+String tvCaptionBgLabel(double opacity) {
+  final nearest = kTvCaptionBackgrounds.reduce(
+    (a, b) => (a.$2 - opacity).abs() <= (b.$2 - opacity).abs() ? a : b,
+  );
+  return nearest.$1;
+}
+
+String tvCaptionEdgeLabel(String outlineType) {
+  final type = tvEdgeTypeFromOutlinePref(outlineType);
+  for (final (_, label, t) in kTvCaptionEdgeTypes) {
+    if (t == type) return label;
+  }
+  return 'Outline';
+}
+
+String tvCaptionPositionLabel(int position) {
+  final nearest = kTvCaptionPositions.reduce(
+    (a, b) => (a.$2 - position).abs() <= (b.$2 - position).abs() ? a : b,
+  );
+  return nearest.$1;
+}
+
+String tvCaptionFontLabel(String font) => font.isEmpty ? 'Default' : font;
+
 class TvCaptionStyle {
   const TvCaptionStyle({
     required this.scale,
     required this.fgColor,
     required this.bgColor,
     required this.edge,
-    required this.position,
     this.fontFamily = '',
+    this.edgeType = kTvEdgeOutline,
   });
   final double scale;
   final int fgColor; // ARGB
   final int bgColor; // ARGB
+
+  /// Legacy: true when [edgeType] is not [kTvEdgeNone].
   final bool edge;
-  final double position; // bottom-padding fraction 0..1
+
+  /// Media3 CaptionStyleCompat edge type.
+  final int edgeType;
   final String fontFamily;
 }
 
@@ -142,21 +254,36 @@ TvSubDecision decideSubtitle({
   return TvSubDecision(TvSubAction.download, language: lang);
 }
 
-/// Maps a bundled subtitle-font family to its asset path (see pubspec fonts).
-String? subtitleFontAsset(String family) {
+/// Maps a subtitle-font family to its `.ttf` filename under `sub_fonts/`
+/// (and under `assets/fonts/` for APK-bundled families).
+String? subtitleFontFileName(String family) {
   const map = {
-    'Inter': 'assets/fonts/Inter.ttf',
-    'Poppins': 'assets/fonts/Poppins-Regular.ttf',
-    'Roboto': 'assets/fonts/Roboto-Regular.ttf',
-    'Open Sans': 'assets/fonts/OpenSans-Regular.ttf',
-    'Lato': 'assets/fonts/Lato-Regular.ttf',
-    'Montserrat': 'assets/fonts/Montserrat-Regular.ttf',
-    'Nunito': 'assets/fonts/Nunito-Regular.ttf',
-    'Rubik': 'assets/fonts/Rubik-Regular.ttf',
-    'Noto Sans': 'assets/fonts/NotoSans-Regular.ttf',
-    'Source Sans 3': 'assets/fonts/SourceSans3-Regular.ttf',
+    'Inter': 'Inter.ttf',
+    'Poppins': 'Poppins-Regular.ttf',
+    'Roboto': 'Roboto-Regular.ttf',
+    'Open Sans': 'OpenSans-Regular.ttf',
+    'Lato': 'Lato-Regular.ttf',
+    'Montserrat': 'Montserrat-Regular.ttf',
+    'Nunito': 'Nunito-Regular.ttf',
+    'Rubik': 'Rubik-Regular.ttf',
+    'Noto Sans': 'NotoSans-Regular.ttf',
+    'Source Sans 3': 'SourceSans3-Regular.ttf',
   };
   return map[family];
+}
+
+/// Asset path for fonts that ship in the APK (see pubspec `flutter: fonts:`).
+/// Download-on-demand families return null — stage them from `sub_fonts/` after
+/// [SubtitleFontService.ensure].
+String? subtitleFontAsset(String family) {
+  switch (family) {
+    case 'Inter':
+      return 'assets/fonts/Inter.ttf';
+    case 'Noto Sans':
+      return 'assets/fonts/NotoSans-Regular.ttf';
+    default:
+      return null;
+  }
 }
 
 /// PlaybackPrefs stores the subtitle colour as `#RRGGBBAA` (default
@@ -174,17 +301,22 @@ TvCaptionStyle captionStyleFromPrefs({
   required double scale,
   required String colorHex,
   required double bgOpacity,
-  required int position,
   required String font,
+  String? outlineType,
 }) {
   final o = bgOpacity.clamp(0.0, 1.0);
   final bgA = (o * 255).round();
+  // Explicit outline pref wins; otherwise keep the legacy heuristic (outline
+  // when there's no background box so text stays readable on busy scenes).
+  final edgeType = outlineType != null
+      ? tvEdgeTypeFromOutlinePref(outlineType)
+      : (o <= 0.0 ? kTvEdgeOutline : kTvEdgeNone);
   return TvCaptionStyle(
     scale: scale,
     fgColor: parseSubtitleColor(colorHex),
     bgColor: bgA << 24, // alpha-black window box
-    edge: o <= 0.0, // outline for readability when there's no box
-    position: ((100 - position).clamp(0, 100)) / 100.0,
+    edge: edgeType != kTvEdgeNone,
+    edgeType: edgeType,
     fontFamily: font,
   );
 }

--- a/lib/features/player/subtitle_font_service.dart
+++ b/lib/features/player/subtitle_font_service.dart
@@ -5,6 +5,9 @@ import 'package:dio/dio.dart';
 import 'package:flutter/services.dart' show FontLoader;
 import 'package:path_provider/path_provider.dart';
 
+import '../../core/playback/playback_prefs.dart' show kBundledSubtitleFonts;
+import '../../core/playback/tv_track_helpers.dart' show subtitleFontFileName;
+
 /// Download-on-demand for subtitle fonts. Only Inter (UI font) and Noto Sans
 /// (the libass Android fallback) ship in the APK; the rest are fetched from the
 /// app's own public repo on first pick, cached to `<appSupport>/sub_fonts/`, and
@@ -16,20 +19,6 @@ import 'package:path_provider/path_provider.dart';
 class SubtitleFontService {
   SubtitleFontService._();
   static final SubtitleFontService instance = SubtitleFontService._();
-
-  /// family name (matches [kBundledSubtitleFonts]) → .ttf filename in the repo.
-  static const Map<String, String> _files = {
-    'Inter': 'Inter.ttf',
-    'Poppins': 'Poppins-Regular.ttf',
-    'Roboto': 'Roboto-Regular.ttf',
-    'Open Sans': 'OpenSans-Regular.ttf',
-    'Lato': 'Lato-Regular.ttf',
-    'Montserrat': 'Montserrat-Regular.ttf',
-    'Nunito': 'Nunito-Regular.ttf',
-    'Rubik': 'Rubik-Regular.ttf',
-    'Noto Sans': 'NotoSans-Regular.ttf',
-    'Source Sans 3': 'SourceSans3-Regular.ttf',
-  };
 
   /// Families bundled in the APK (registered in pubspec) — always available.
   static const Set<String> bundled = {'Inter', 'Noto Sans'};
@@ -55,7 +44,7 @@ class SubtitleFontService {
   /// True when [family] is usable right now (Default, bundled, or downloaded).
   Future<bool> isAvailable(String family) async {
     if (family.isEmpty || bundled.contains(family)) return true;
-    final fname = _files[family];
+    final fname = subtitleFontFileName(family);
     if (fname == null) return false;
     final dir = await _fontsDir();
     return File('${dir.path}/$fname').existsSync();
@@ -65,7 +54,7 @@ class SubtitleFontService {
   /// (already-available counts as success). Never throws.
   Future<bool> ensure(String family) async {
     if (family.isEmpty || bundled.contains(family)) return true;
-    final fname = _files[family];
+    final fname = subtitleFontFileName(family);
     if (fname == null) return false;
     try {
       final dir = await _fontsDir();
@@ -102,10 +91,12 @@ class SubtitleFontService {
   Future<void> registerCached() async {
     try {
       final dir = await _fontsDir();
-      for (final entry in _files.entries) {
-        if (bundled.contains(entry.key)) continue;
-        final f = File('${dir.path}/${entry.value}');
-        if (f.existsSync()) await _register(entry.key, f);
+      for (final family in kBundledSubtitleFonts) {
+        if (family.isEmpty || bundled.contains(family)) continue;
+        final fname = subtitleFontFileName(family);
+        if (fname == null) continue;
+        final f = File('${dir.path}/$fname');
+        if (f.existsSync()) await _register(family, f);
       }
     } catch (_) {}
   }

--- a/lib/features/player/tv_exo_controller.dart
+++ b/lib/features/player/tv_exo_controller.dart
@@ -142,14 +142,19 @@ class TvExoController {
   /// ExoPlayer. Never reopens anything, so position and server are untouched.
   Future<void> selectVideoTrack(String? id) =>
       _method.invokeMethod('selectVideoTrack', {'id': id});
-  Future<void> applyCaptionStyle(TvCaptionStyle s, {String? fontPath}) =>
+  Future<void> applyCaptionStyle(
+    TvCaptionStyle s, {
+    String? fontPath,
+    required int positionPref,
+  }) =>
       _method.invokeMethod('setCaptionStyle', {
         'scale': s.scale,
         'fontPath': fontPath,
         'fgColor': s.fgColor,
         'bgColor': s.bgColor,
         'edge': s.edge,
-        'position': s.position,
+        'edgeType': s.edgeType,
+        'positionPref': positionPref,
       });
   Future<void> setPlaybackSpeed(double speed) =>
       _method.invokeMethod('setPlaybackSpeed', {'speed': speed});

--- a/lib/features/player/tv_exo_player_screen.dart
+++ b/lib/features/player/tv_exo_player_screen.dart
@@ -25,6 +25,7 @@ import '../../core/playback/skip_service.dart';
 import '../../core/playback/source_selection.dart';
 import '../../core/playback/subtitle_download_service.dart';
 import '../../core/playback/subtitle_font_stage.dart';
+import 'subtitle_font_service.dart';
 import '../../core/playback/subtitle_language.dart';
 import '../../core/playback/subtitle_search_service.dart';
 import '../../core/playback/title_prefs.dart';
@@ -115,6 +116,10 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   HlsVariant? _activeQuality; // null = Auto
   int? _seekTargetMs; // one-shot seek on next ready (resume OR source switch)
   bool _menuOpen = false;
+  /// Drill-in stack for the Settings side panel. Empty = root "Settings" page.
+  final List<_TvSettingsPage> _menuStack = [];
+  /// When true, the right-side panel is the Speed picker (opened from speed pill).
+  bool _speedMenuOpen = false;
   double _speed = 1.0;
   // Focus for the player root (D-pad controls) and the up-next card. Overlays
   // (menu / search / up-next) must explicitly grab focus and hand it back here,
@@ -252,12 +257,16 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
       if (!mounted) return;
       if (_c?.playing.value == true &&
           !_menuOpen &&
+          !_speedMenuOpen &&
           !_episodesOpen &&
           !_controlRowFocused &&
           !_scrubbing &&
           _searchResults == null &&
           _upNextCountdown == null) {
-        setState(() => _controlsVisible = false);
+        setState(() {
+          _controlsVisible = false;
+          _speedMenuOpen = false;
+        });
       }
     });
   }
@@ -269,6 +278,10 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   void _toggleControlsFromTouch() {
     if (_menuOpen) {
       _closeMenu();
+      return;
+    }
+    if (_speedMenuOpen) {
+      _closeSpeedMenu();
       return;
     }
     if (_searchResults != null) {
@@ -728,20 +741,26 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
       scale: p.subtitleScale,
       colorHex: p.subtitleColorHex,
       bgOpacity: p.subtitleBgOpacity,
-      position: p.subtitlePosition,
       font: p.subtitleFont,
+      outlineType: p.subtitleOutlineType,
     );
     final path = await _stageFont(style.fontFamily);
-    _c?.applyCaptionStyle(style, fontPath: path);
+    _c?.applyCaptionStyle(
+      style,
+      fontPath: path,
+      positionPref: p.subtitlePosition,
+    );
   }
 
-  /// Stages the chosen bundled font once (shared with the native TV player) and
+  /// Stages the chosen font once (shared with the native TV player) and
   /// caches the path so repeated style changes don't re-copy. Null for default.
+  /// Download-on-demand families are fetched via [SubtitleFontService] first.
   Future<String?> _stageFont(String family) async {
     if (family.isEmpty) return null;
     if (family == _stagedFontFamily && _stagedFontPath != null) {
       return _stagedFontPath;
     }
+    await SubtitleFontService.instance.ensure(family);
     final path = await stageSubtitleFont(family);
     if (path != null) {
       _stagedFontFamily = family;
@@ -837,101 +856,219 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     }();
   }
 
-  List<TvMenuSection> _buildSections(TvExoController c) {
-    final sections = <TvMenuSection>[];
+  List<TvMenuOption> _buildMenuOptions(TvExoController c) {
+    final page =
+        _menuStack.isEmpty ? _TvSettingsPage.root : _menuStack.last;
+    switch (page) {
+      case _TvSettingsPage.root:
+        return _rootSettingsOptions(c);
+      case _TvSettingsPage.servers:
+        return _serversOptions(c);
+      case _TvSettingsPage.quality:
+        return _qualityOptions(c);
+      case _TvSettingsPage.audio:
+        return _audioOptions(c);
+      case _TvSettingsPage.subs:
+        return _subsOptions(c);
+      case _TvSettingsPage.captionStyle:
+        return _captionStyleOptions();
+      case _TvSettingsPage.captionSize:
+        return _captionSizeOptions();
+      case _TvSettingsPage.captionColor:
+        return _captionColorOptions();
+      case _TvSettingsPage.captionEdge:
+        return _captionEdgeOptions();
+      case _TvSettingsPage.captionBg:
+        return _captionBgOptions();
+      case _TvSettingsPage.captionFont:
+        return _captionFontOptions();
+      case _TvSettingsPage.captionPos:
+        return _captionPosOptions();
+      case _TvSettingsPage.volume:
+        return _volumeOptions();
+    }
+  }
 
-    // Servers — every resolved mirror for the current sub/dub kind, so the user
-    // can switch when one is slow or dead (mirrors the phone player's Sources).
+  String get _menuTitle {
+    if (_menuStack.isEmpty) return 'Settings';
+    return switch (_menuStack.last) {
+      _TvSettingsPage.root => 'Settings',
+      _TvSettingsPage.servers => 'Servers',
+      _TvSettingsPage.quality => 'Quality',
+      _TvSettingsPage.audio => 'Audio',
+      _TvSettingsPage.subs => 'Subtitles/CC',
+      _TvSettingsPage.captionStyle => 'Captions Styling',
+      _TvSettingsPage.captionSize => 'Font Size',
+      _TvSettingsPage.captionColor => 'Text Color',
+      _TvSettingsPage.captionEdge => 'Edge Style',
+      _TvSettingsPage.captionBg => 'Background',
+      _TvSettingsPage.captionFont => 'Font',
+      _TvSettingsPage.captionPos => 'Position',
+      _TvSettingsPage.volume => 'Volume',
+    };
+  }
+
+  void _pushMenu(_TvSettingsPage page) {
+    setState(() => _menuStack.add(page));
+    _bumpMenuHide();
+  }
+
+  void _popOrCloseMenu() {
+    if (_menuStack.isNotEmpty) {
+      setState(() => _menuStack.removeLast());
+      _bumpMenuHide();
+    } else {
+      _closeMenu();
+    }
+  }
+
+  TvMenuOption _navRow(String label, {String? trailing, required VoidCallback onSelect}) =>
+      TvMenuOption(
+        label: label,
+        trailing: trailing,
+        showCheck: false,
+        onSelect: onSelect,
+      );
+
+  List<TvMenuOption> _rootSettingsOptions(TvExoController c) {
+    final options = <TvMenuOption>[];
     final servers = sortByQuality(_qualityPool());
     if (servers.length > 1) {
-      sections.add(
-        TvMenuSection(
-          title: 'Servers',
-          options: [
-            for (final s in servers)
-              TvMenuOption(
-                label: _serverLabel(s),
-                selected: s.url == _activeSource?.url,
-                onSelect: () => _open(s, seekToMs: c.position.value),
-              ),
-          ],
-        ),
-      );
+      final active = servers.where((s) => s.url == _activeSource?.url).firstOrNull;
+      options.add(_navRow(
+        'Servers',
+        trailing: active != null ? _serverLabel(active) : null,
+        onSelect: () => _pushMenu(_TvSettingsPage.servers),
+      ));
     }
 
-    // Quality
-    final qOptions = <TvMenuOption>[];
+    final qTrailing = _qualityTrailing(c);
+    if (qTrailing != null) {
+      options.add(_navRow(
+        'Quality',
+        trailing: qTrailing,
+        onSelect: () => _pushMenu(_TvSettingsPage.quality),
+      ));
+    }
+
+    final audio = c.audioTracks.value;
+    final audioLabel = _selectedTrackLabel(audio) ??
+        (_category == 'dub' ? 'Dub' : 'Sub');
+    options.add(_navRow(
+      'Audio',
+      trailing: audioLabel,
+      onSelect: () => _pushMenu(_TvSettingsPage.audio),
+    ));
+
+    final text = c.textTracks.value;
+    final selectedSub = _selectedTrackLabel(text);
+    final subsOff = selectedSub == null;
+    options.add(_navRow(
+      'Subtitles/CC',
+      trailing: subsOff ? 'Off' : selectedSub,
+      onSelect: () => _pushMenu(_TvSettingsPage.subs),
+    ));
+
+    options.add(_navRow(
+      'Captions Styling',
+      onSelect: () => _pushMenu(_TvSettingsPage.captionStyle),
+    ));
+
+    final vol = sl<PlaybackPrefs>().volumeBoost;
+    options.add(_navRow(
+      'Volume',
+      trailing: vol == 100 ? '100%' : '$vol%',
+      onSelect: () => _pushMenu(_TvSettingsPage.volume),
+    ));
+    return options;
+  }
+
+  String? _qualityTrailing(TvExoController c) {
     if (_qualities.isNotEmpty) {
-      qOptions.add(
-        TvMenuOption(
-          label: 'Auto',
-          selected: _activeQuality == null,
-          onSelect: () => _selectQuality(null),
-        ),
-      );
-      for (final v in _qualities) {
-        qOptions.add(
-          TvMenuOption(
-            label: v.quality,
-            selected: _activeQuality?.url == v.url,
-            onSelect: () => _selectQuality(v),
-          ),
-        );
-      }
-    } else if (c.videoTracks.value.length > 1) {
-      // No parsed HLS master, but ExoPlayer found a ladder inside the stream
-      // itself — a DASH manifest, or an HLS one our own parser couldn't read.
-      // Same deal as the phone: these are renditions of the file that is
-      // already playing, so switching is a track override, not a reload.
+      return _activeQuality?.quality ?? 'Auto';
+    }
+    if (c.videoTracks.value.length > 1) {
       final tracks = c.videoTracks.value;
       final overridden = tracks.any((t) => t.id == _activeVideoTrackId);
-      qOptions.add(
-        TvMenuOption(
-          label: 'Auto',
-          selected: !overridden,
-          onSelect: () => _selectVideoTrack(null),
-        ),
-      );
-      for (final t in tracks) {
-        qOptions.add(
-          TvMenuOption(
-            label: '${t.height}p',
-            selected: overridden && t.id == _activeVideoTrackId,
-            onSelect: () => _selectVideoTrack(t),
-          ),
-        );
+      if (!overridden) return 'Auto';
+      final t = tracks.where((t) => t.id == _activeVideoTrackId).firstOrNull;
+      return t?.height != null ? '${t!.height}p' : 'Track';
+    }
+    return null;
+  }
+
+  String? _selectedTrackLabel(List<TvTrack> tracks) {
+    for (final t in tracks) {
+      if (t.selected) {
+        return t.label ?? (t.language.isEmpty ? null : t.language);
       }
     }
-    // Anything else has one video track: nothing to switch inside it, so the
-    // section is left out. The other sources are separate files on separate
-    // servers — they live under Sources, where switching to one looks like what
-    // it is.
-    if (qOptions.isNotEmpty) {
-      sections.add(TvMenuSection(title: 'Quality', options: qOptions));
-    }
+    return null;
+  }
 
-    // Audio
-    final audio = c.audioTracks.value;
-    if (audio.length > 1) {
-      sections.add(
-        TvMenuSection(
-          title: 'Audio',
-          options: [
-            for (final t in audio)
-              TvMenuOption(
-                label: t.label ?? (t.language.isEmpty ? 'Track' : t.language),
-                selected: t.selected,
-                onSelect: () => _selectAudio(t),
-              ),
-          ],
+  List<TvMenuOption> _serversOptions(TvExoController c) {
+    final servers = sortByQuality(_qualityPool());
+    return [
+      for (final s in servers)
+        TvMenuOption(
+          label: _serverLabel(s),
+          selected: s.url == _activeSource?.url,
+          onSelect: () {
+            _open(s, seekToMs: c.position.value);
+            _popOrCloseMenu();
+          },
         ),
-      );
-    }
+    ];
+  }
 
-    // Version (sub/dub). Show when the resolved pool carries both kinds OR the
-    // show advertises both via its detail counts — separate sub/dub episode
-    // lists only ever resolve one kind at a time, so the pool check alone would
-    // hide the toggle for most anime.
+  List<TvMenuOption> _qualityOptions(TvExoController c) {
+    final options = <TvMenuOption>[];
+    if (_qualities.isNotEmpty) {
+      options.add(TvMenuOption(
+        label: 'Auto',
+        selected: _activeQuality == null,
+        onSelect: () {
+          _selectQuality(null);
+          setState(() {});
+        },
+      ));
+      for (final v in _qualities) {
+        options.add(TvMenuOption(
+          label: v.quality,
+          selected: _activeQuality?.url == v.url,
+          onSelect: () {
+            _selectQuality(v);
+            setState(() {});
+          },
+        ));
+      }
+    } else if (c.videoTracks.value.length > 1) {
+      final tracks = c.videoTracks.value;
+      final overridden = tracks.any((t) => t.id == _activeVideoTrackId);
+      options.add(TvMenuOption(
+        label: 'Auto',
+        selected: !overridden,
+        onSelect: () {
+          _selectVideoTrack(null);
+          setState(() {});
+        },
+      ));
+      for (final t in tracks) {
+        options.add(TvMenuOption(
+          label: '${t.height}p',
+          selected: overridden && t.id == _activeVideoTrackId,
+          onSelect: () {
+            _selectVideoTrack(t);
+            setState(() {});
+          },
+        ));
+      }
+    }
+    return options;
+  }
+
+  List<TvMenuOption> _audioOptions(TvExoController c) {
+    final options = <TvMenuOption>[];
     final kinds = availableKinds(_sources);
     final poolHasBoth =
         kinds.contains(AudioKind.sub) && kinds.contains(AudioKind.dub);
@@ -939,28 +1076,39 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
         widget.availableCategories.contains('sub') &&
         widget.availableCategories.contains('dub');
     if (poolHasBoth || showHasBoth) {
-      sections.add(
-        TvMenuSection(
-          title: 'Version',
-          options: [
-            TvMenuOption(
-              label: 'Sub',
-              selected: _category == 'sub',
-              onSelect: () => _switchCategory('sub'),
-            ),
-            TvMenuOption(
-              label: 'Dub',
-              selected: _category == 'dub',
-              onSelect: () => _switchCategory('dub'),
-            ),
-          ],
-        ),
-      );
+      options.add(TvMenuOption(
+        label: 'Sub',
+        selected: _category == 'sub',
+        onSelect: () => _switchCategory('sub'),
+      ));
+      options.add(TvMenuOption(
+        label: 'Dub',
+        selected: _category == 'dub',
+        onSelect: () => _switchCategory('dub'),
+      ));
     }
+    final audio = c.audioTracks.value;
+    if (audio.isEmpty) {
+      options.add(TvMenuOption(
+        label: 'Default',
+        selected: true,
+        onSelect: () {},
+      ));
+    } else {
+      for (final t in audio) {
+        options.add(TvMenuOption(
+          label: t.label ?? (t.language.isEmpty ? 'Track' : t.language),
+          selected: t.selected,
+          onSelect: () => _selectAudio(t),
+        ));
+      }
+    }
+    return options;
+  }
 
-    // Subtitles
+  List<TvMenuOption> _subsOptions(TvExoController c) {
     final text = c.textTracks.value;
-    final subOptions = <TvMenuOption>[
+    return [
       TvMenuOption(
         label: 'Off',
         selected: text.every((t) => !t.selected),
@@ -974,62 +1122,185 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
         ),
       TvMenuOption(
         label: 'Preferred language…',
+        showCheck: false,
         onSelect: _pickPreferredLanguage,
       ),
-      TvMenuOption(label: 'Search online…', onSelect: _openSubtitleSearch),
       TvMenuOption(
-        label: 'Subtitle size',
-        trailing: _sizeLabel(sl<PlaybackPrefs>().subtitleScale),
-        onSelect: _cycleSubtitleSize,
-      ),
-      TvMenuOption(
-        label: 'Background',
-        trailing: sl<PlaybackPrefs>().subtitleBgOpacity > 0 ? 'On' : 'Off',
-        onSelect: _toggleSubtitleBackground,
+        label: 'Search online…',
+        showCheck: false,
+        onSelect: _openSubtitleSearch,
       ),
     ];
-    sections.add(TvMenuSection(title: 'Subtitles', options: subOptions));
+  }
 
-    // Speed
-    sections.add(
-      TvMenuSection(
-        title: 'Speed',
-        options: [
-          for (final s in kTvSpeeds)
-            TvMenuOption(
-              label: s == 1.0 ? 'Normal' : '${s}x',
-              selected: (_speed - s).abs() < 0.001,
-              onSelect: () => _setSpeed(s),
-            ),
-        ],
+  List<TvMenuOption> _captionStyleOptions() {
+    final p = sl<PlaybackPrefs>();
+    return [
+      _navRow(
+        'Font Size',
+        trailing: tvCaptionSizeLabel(p.subtitleScale),
+        onSelect: () => _pushMenu(_TvSettingsPage.captionSize),
       ),
-    );
+      _navRow(
+        'Text Color',
+        trailing: tvCaptionColorLabel(p.subtitleColorHex),
+        onSelect: () => _pushMenu(_TvSettingsPage.captionColor),
+      ),
+      _navRow(
+        'Edge Style',
+        trailing: tvCaptionEdgeLabel(p.subtitleOutlineType),
+        onSelect: () => _pushMenu(_TvSettingsPage.captionEdge),
+      ),
+      _navRow(
+        'Background',
+        trailing: tvCaptionBgLabel(p.subtitleBgOpacity),
+        onSelect: () => _pushMenu(_TvSettingsPage.captionBg),
+      ),
+      _navRow(
+        'Font',
+        trailing: tvCaptionFontLabel(p.subtitleFont),
+        onSelect: () => _pushMenu(_TvSettingsPage.captionFont),
+      ),
+      _navRow(
+        'Position',
+        trailing: tvCaptionPositionLabel(p.subtitlePosition),
+        onSelect: () => _pushMenu(_TvSettingsPage.captionPos),
+      ),
+    ];
+  }
 
-    // Volume boost
+  List<TvMenuOption> _captionSizeOptions() {
+    final current = sl<PlaybackPrefs>().subtitleScale;
+    return [
+      for (final (label, scale) in kTvCaptionSizes)
+        TvMenuOption(
+          label: label,
+          selected: tvCaptionSizeLabel(current) == label,
+          onSelect: () => _setCaptionScale(scale),
+        ),
+    ];
+  }
+
+  List<TvMenuOption> _captionColorOptions() {
+    final current = sl<PlaybackPrefs>().subtitleColorHex.toUpperCase();
+    return [
+      for (final (hex, label) in kTvCaptionColors)
+        TvMenuOption(
+          label: label,
+          selected: current == hex,
+          onSelect: () => _setCaptionColor(hex),
+        ),
+    ];
+  }
+
+  List<TvMenuOption> _captionEdgeOptions() {
+    final current = tvEdgeTypeFromOutlinePref(
+      sl<PlaybackPrefs>().subtitleOutlineType,
+    );
+    return [
+      for (final (id, label, type) in kTvCaptionEdgeTypes)
+        TvMenuOption(
+          label: label,
+          selected: current == type,
+          onSelect: () => _setCaptionEdge(id),
+        ),
+    ];
+  }
+
+  List<TvMenuOption> _captionBgOptions() {
+    final current = sl<PlaybackPrefs>().subtitleBgOpacity;
+    return [
+      for (final (label, opacity) in kTvCaptionBackgrounds)
+        TvMenuOption(
+          label: label,
+          selected: tvCaptionBgLabel(current) == label,
+          onSelect: () => _setCaptionBg(opacity),
+        ),
+    ];
+  }
+
+  List<TvMenuOption> _captionFontOptions() {
+    final current = sl<PlaybackPrefs>().subtitleFont;
+    return [
+      for (final f in kBundledSubtitleFonts)
+        TvMenuOption(
+          label: tvCaptionFontLabel(f),
+          selected: current == f,
+          onSelect: () => _setCaptionFont(f),
+        ),
+    ];
+  }
+
+  List<TvMenuOption> _captionPosOptions() {
+    final current = sl<PlaybackPrefs>().subtitlePosition;
+    return [
+      for (final (label, pos) in kTvCaptionPositions)
+        TvMenuOption(
+          label: label,
+          selected: tvCaptionPositionLabel(current) == label,
+          onSelect: () => _setCaptionPos(pos),
+        ),
+    ];
+  }
+
+  List<TvMenuOption> _volumeOptions() {
     const volSteps = [100, 125, 150, 175, 200];
     final vol = sl<PlaybackPrefs>().volumeBoost;
-    sections.add(
-      TvMenuSection(
-        title: 'Volume',
-        options: [
-          for (final v in volSteps)
-            TvMenuOption(
-              label: v == 100 ? '100% (normal)' : '$v%',
-              selected: vol == v,
-              onSelect: () => _setVolume(v),
-            ),
-        ],
-      ),
-    );
+    return [
+      for (final v in volSteps)
+        TvMenuOption(
+          label: v == 100 ? '100% (normal)' : '$v%',
+          selected: vol == v,
+          onSelect: () => _setVolume(v),
+        ),
+    ];
+  }
 
-    return sections;
+  Future<void> _setCaptionScale(double scale) async {
+    await sl<PlaybackPrefs>().setSubtitleScale(scale);
+    await _applyCaptionStyle();
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _setCaptionColor(String hex) async {
+    await sl<PlaybackPrefs>().setSubtitleColorHex(hex);
+    await _applyCaptionStyle();
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _setCaptionEdge(String id) async {
+    await sl<PlaybackPrefs>().setSubtitleOutlineType(id);
+    await _applyCaptionStyle();
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _setCaptionBg(double opacity) async {
+    await sl<PlaybackPrefs>().setSubtitleBgOpacity(opacity);
+    await _applyCaptionStyle();
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _setCaptionFont(String font) async {
+    await sl<PlaybackPrefs>().setSubtitleFont(font);
+    await _applyCaptionStyle();
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _setCaptionPos(int pos) async {
+    await sl<PlaybackPrefs>().setSubtitlePosition(pos);
+    await _applyCaptionStyle();
+    if (mounted) setState(() {});
   }
 
   void _setSpeed(double s) {
-    setState(() => _speed = s);
+    setState(() {
+      _speed = s;
+      _speedMenuOpen = false;
+    });
     _c?.setPlaybackSpeed(s);
     sl<TitlePrefsStore>().setSpeed(widget.sourceId, _resumeShowId, s);
     sl<PlaybackPrefs>().setDefaultSpeed(s);
+    _rootFocus.requestFocus();
   }
 
   void _setVolume(int v) {
@@ -1038,23 +1309,20 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     if (mounted) setState(() {});
   }
 
-  String _sizeLabel(double s) => s <= 0.85 ? 'S' : (s >= 1.2 ? 'L' : 'M');
-
-  Future<void> _cycleSubtitleSize() async {
-    final p = sl<PlaybackPrefs>();
-    final next = p.subtitleScale <= 0.85
-        ? 1.0
-        : (p.subtitleScale >= 1.2 ? 0.8 : 1.3);
-    await p.setSubtitleScale(next);
-    await _applyCaptionStyle();
-    if (mounted) setState(() {});
+  void _openSpeedMenu() {
+    setState(() {
+      _speedMenuOpen = true;
+      _menuOpen = false;
+      _menuStack.clear();
+    });
+    _bumpMenuHide();
   }
 
-  Future<void> _toggleSubtitleBackground() async {
-    final p = sl<PlaybackPrefs>();
-    await p.setSubtitleBgOpacity(p.subtitleBgOpacity > 0 ? 0.0 : 0.6);
-    await _applyCaptionStyle();
-    if (mounted) setState(() {});
+  void _closeSpeedMenu() {
+    _menuHideTimer?.cancel();
+    _stampOverlayClose();
+    setState(() => _speedMenuOpen = false);
+    _rootFocus.requestFocus();
   }
 
   Future<void> _pickPreferredLanguage() async {
@@ -1134,7 +1402,11 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   }
 
   void _openMenu() {
-    setState(() => _menuOpen = true);
+    setState(() {
+      _menuOpen = true;
+      _menuStack.clear();
+      _speedMenuOpen = false;
+    });
     _bumpMenuHide();
   }
 
@@ -1143,14 +1415,22 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   void _bumpMenuHide() {
     _menuHideTimer?.cancel();
     _menuHideTimer = Timer(const Duration(seconds: 15), () {
-      if (mounted && _menuOpen) _closeMenu();
+      if (!mounted) return;
+      if (_menuOpen) {
+        _closeMenu();
+      } else if (_speedMenuOpen) {
+        _closeSpeedMenu();
+      }
     });
   }
 
   void _closeMenu() {
     _menuHideTimer?.cancel();
     _stampOverlayClose();
-    setState(() => _menuOpen = false);
+    setState(() {
+      _menuOpen = false;
+      _menuStack.clear();
+    });
     _rootFocus.requestFocus(); // hand D-pad back to the player controls
   }
 
@@ -1390,6 +1670,7 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
     // While an overlay (menu / online search / up-next) is up, it owns the
     // D-pad: let its focused widget + traversal handle keys, don't eat them.
     if (_menuOpen ||
+        _speedMenuOpen ||
         _episodesOpen ||
         _searchResults != null ||
         _upNextCountdown != null) {
@@ -1540,6 +1821,7 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   Widget build(BuildContext context) {
     final overlayOpen =
         _menuOpen ||
+        _speedMenuOpen ||
         _episodesOpen ||
         _searchResults != null ||
         _upNextCountdown != null;
@@ -1561,6 +1843,8 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
           _closeEpisodes();
         } else if (_menuOpen) {
           _closeMenu();
+        } else if (_speedMenuOpen) {
+          _closeSpeedMenu();
         } else if (_upNextCountdown != null) {
           _cancelUpNext();
         } else if (_controlsVisible && !_justClosedOverlay) {
@@ -1690,15 +1974,25 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
                       // fades out on the same 5s timer instead of sitting on the
                       // video the whole episode. (The AniSkip pill above still
                       // shows for its interval, Netflix-style.)
-                      if (sl<PlaybackPrefs>().megaSkip && _controlsVisible) {
+                      if (_controlsVisible) {
                         final secs = sl<PlaybackPrefs>().megaSkipSeconds;
+                        final showMega = sl<PlaybackPrefs>().megaSkip;
                         children.add(
-                          _pillButton('+${secs}s', () {
-                            final c = _c;
-                            if (c != null) {
-                              c.seek(c.position.value + secs * 1000);
-                            }
-                          }),
+                          Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              _speedPill(),
+                              if (showMega) ...[
+                                const SizedBox(width: 8),
+                                _pillButton('+${secs}s', () {
+                                  final c = _c;
+                                  if (c != null) {
+                                    c.seek(c.position.value + secs * 1000);
+                                  }
+                                }),
+                              ],
+                            ],
+                          ),
                         );
                       }
                       if (children.isEmpty) return const SizedBox.shrink();
@@ -1778,30 +2072,44 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
                     ),
                   ),
                 ),
+              if (_speedMenuOpen)
+                TvTrackMenu(
+                  key: const ValueKey('menu-speed'),
+                  title: 'Speed',
+                  options: [
+                    for (final s in kTvSpeeds)
+                      TvMenuOption(
+                        label: s == 1.0 ? 'Normal' : '$s×',
+                        selected: (_speed - s).abs() < 0.001,
+                        onSelect: () => _setSpeed(s),
+                      ),
+                  ],
+                  onClose: _closeSpeedMenu,
+                  onInteract: _bumpMenuHide,
+                ),
               if (_menuOpen && _c != null)
                 TvTrackMenu(
-                  sections: _buildSections(_c!),
-                  onClose: _closeMenu,
+                  key: ValueKey('menu-$_menuTitle-${_menuStack.length}'),
+                  title: _menuTitle,
+                  options: _buildMenuOptions(_c!),
+                  onClose: _popOrCloseMenu,
                   onInteract: _bumpMenuHide,
                 ),
               if (_searchResults != null)
                 TvTrackMenu(
+                  title: 'Online subtitles',
                   onClose: () {
                     setState(() => _searchResults = null);
                     _rootFocus.requestFocus();
                   },
-                  sections: [
-                    TvMenuSection(
-                      title: 'Online subtitles',
-                      options: [
-                        for (final r in _searchResults!)
-                          TvMenuOption(
-                            label: r.name,
-                            trailing: r.language,
-                            onSelect: () => _applySearchResult(r),
-                          ),
-                      ],
-                    ),
+                  options: [
+                    for (final r in _searchResults!)
+                      TvMenuOption(
+                        label: r.name,
+                        trailing: r.language,
+                        showCheck: false,
+                        onSelect: () => _applySearchResult(r),
+                      ),
                   ],
                 ),
             ],
@@ -2278,4 +2586,74 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
       ),
     );
   }
+
+  Widget _speedPill() {
+    final label = (_speed - 1.0).abs() < 0.001 ? '1×' : '$_speed×';
+    return Focus(
+      onKeyEvent: (_, e) {
+        if (e is! KeyDownEvent) return KeyEventResult.ignored;
+        if (okKeys.contains(e.logicalKey)) {
+          _openSpeedMenu();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: Builder(
+        builder: (context) {
+          final focused = Focus.of(context).hasFocus;
+          return GestureDetector(
+            onTap: () {
+              Focus.of(context).requestFocus();
+              _openSpeedMenu();
+            },
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.7),
+                borderRadius: BorderRadius.circular(24),
+                border: Border.all(
+                  color: focused || _speedMenuOpen
+                      ? AppColors.accent
+                      : Colors.white38,
+                  width: 2,
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.speed,
+                    size: 18,
+                    color: Colors.white.withValues(alpha: 0.95),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    label,
+                    style: const TextStyle(color: Colors.white, fontSize: 15),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Drill-in pages for the Flutter TV Settings side panel.
+enum _TvSettingsPage {
+  root,
+  servers,
+  quality,
+  audio,
+  subs,
+  captionStyle,
+  captionSize,
+  captionColor,
+  captionEdge,
+  captionBg,
+  captionFont,
+  captionPos,
+  volume,
 }

--- a/lib/features/player/tv_native_player.dart
+++ b/lib/features/player/tv_native_player.dart
@@ -25,6 +25,7 @@ import '../../core/theme/app_colors.dart';
 import '../../core/torrent/torrent_prefs.dart';
 import '../../core/torrent/torrent_service.dart';
 import '../../core/torrent/torrent_util.dart';
+import 'subtitle_font_service.dart';
 
 /// Launches and services the fully-native TV player (TvPlayerActivity —
 /// real-window ExoPlayer/SurfaceView) instead of the Flutter platform-view
@@ -115,16 +116,19 @@ class TvNativePlayer {
     final mark = resume.get(sourceId, _showId, ep.id);
 
     // Full subtitle style, computed the SAME way as the Flutter PlatformView TV
-    // player so both render identically (colour, box, outline, position, font).
+    // player so both render identically (colour, box, outline, font).
     final prefs = sl<PlaybackPrefs>();
     final subStyle = captionStyleFromPrefs(
       scale: prefs.subtitleScale,
       colorHex: prefs.subtitleColorHex,
       bgOpacity: prefs.subtitleBgOpacity,
-      position: prefs.subtitlePosition,
       font: prefs.subtitleFont,
+      outlineType: prefs.subtitleOutlineType,
     );
-    final subFontPath = await stageSubtitleFont(prefs.subtitleFont);
+    final subFontPath = await () async {
+      await SubtitleFontService.instance.ensure(prefs.subtitleFont);
+      return stageSubtitleFont(prefs.subtitleFont);
+    }();
 
     // Discord Rich Presence: the native Activity runs outside the Flutter
     // engine and can't reach the Dart Discord service, so announce "Watching"
@@ -177,7 +181,12 @@ class TvNativePlayer {
       'subtitleFgColor': subStyle.fgColor,
       'subtitleBgColor': subStyle.bgColor,
       'subtitleEdge': subStyle.edge,
-      'subtitlePosition': subStyle.position,
+      'subtitleEdgeType': subStyle.edgeType,
+      'subtitleColorHex': prefs.subtitleColorHex,
+      'subtitleOutlineType': prefs.subtitleOutlineType,
+      'subtitleFontFamily': prefs.subtitleFont,
+      'subtitlePositionPref': prefs.subtitlePosition,
+      'subtitleBgOpacity': prefs.subtitleBgOpacity,
       'subtitleFontPath': ?subFontPath,
       'subtitleApiKeySet': prefs.subtitleApiKey.trim().isNotEmpty,
       'megaSkip': prefs.megaSkip,
@@ -261,6 +270,37 @@ class TvNativePlayer {
         final s = (call.arguments as Map)['scale'] as num?;
         if (s != null) await sl<PlaybackPrefs>().setSubtitleScale(s.toDouble());
         return null;
+      case 'setSubtitleColorHex':
+        final hex = (call.arguments as Map)['hex'] as String?;
+        if (hex != null) await sl<PlaybackPrefs>().setSubtitleColorHex(hex);
+        return null;
+      case 'setSubtitleBgOpacity':
+        final o = (call.arguments as Map)['opacity'] as num?;
+        if (o != null) {
+          await sl<PlaybackPrefs>().setSubtitleBgOpacity(o.toDouble());
+        }
+        return null;
+      case 'setSubtitleOutlineType':
+        final t = (call.arguments as Map)['type'] as String?;
+        if (t != null) await sl<PlaybackPrefs>().setSubtitleOutlineType(t);
+        return null;
+      case 'setSubtitleFont':
+        final f = (call.arguments as Map)['font'] as String?;
+        if (f != null) await sl<PlaybackPrefs>().setSubtitleFont(f);
+        return null;
+      case 'setSubtitlePosition':
+        final p = (call.arguments as Map)['position'] as num?;
+        if (p != null) await sl<PlaybackPrefs>().setSubtitlePosition(p.toInt());
+        return null;
+      case 'setDefaultSpeed':
+        final s = (call.arguments as Map)['speed'] as num?;
+        if (s != null) await sl<PlaybackPrefs>().setDefaultSpeed(s.toDouble());
+        return null;
+      case 'stageSubtitleFont':
+        final font = (call.arguments as Map)['font'] as String? ?? '';
+        if (font.isEmpty) return null;
+        await SubtitleFontService.instance.ensure(font);
+        return await stageSubtitleFont(font);
       case 'searchSubtitles':
         // OpenSubtitles search for the current show; results cached for download.
         final pref = sl<PlaybackPrefs>().subtitlePreference;

--- a/lib/features/player/tv_track_menu.dart
+++ b/lib/features/player/tv_track_menu.dart
@@ -4,43 +4,55 @@ import 'package:flutter/services.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/tv/tv_keys.dart';
 
-/// One selectable row in a [TvTrackMenu] section.
+/// One selectable row in a [TvTrackMenu].
 class TvMenuOption {
   const TvMenuOption({
     required this.label,
     this.selected = false,
     this.trailing,
+    this.showCheck = true,
     required this.onSelect,
   });
   final String label;
   final bool selected;
   final String? trailing;
+
+  /// When false, renders a summary/nav row (label + trailing, no check icon).
+  final bool showCheck;
   final VoidCallback onSelect;
 }
 
-/// A titled group of options.
+/// A titled group of options (legacy multi-section menus).
 class TvMenuSection {
   const TvMenuSection({required this.title, required this.options});
   final String title;
   final List<TvMenuOption> options;
 }
 
-/// A D-pad-navigable right-side panel of track sections. Up/Down move focus,
-/// OK selects, Back closes. Presentational: the screen supplies the sections
-/// and the per-option callbacks.
+/// A D-pad-navigable right-side settings panel. Up/Down move focus, OK selects,
+/// Back invokes [onClose] (host pops a sub-page or dismisses).
 ///
-/// Self-focusing: the player's root `Focus` already holds focus when this opens,
-/// so `autofocus` alone can't move focus here — the menu owns a [FocusScopeNode]
-/// and grabs focus explicitly once mounted, then the first row autofocuses.
+/// Prefer [title] + [options] for the Crunchyroll-style Settings list. [sections]
+/// remains for callers that still group rows under headers.
 class TvTrackMenu extends StatefulWidget {
   const TvTrackMenu({
     super.key,
-    required this.sections,
+    this.title = 'Settings',
+    this.options = const [],
+    this.sections = const [],
     required this.onClose,
     this.onInteract,
   });
 
+  /// Panel / page title shown at the top.
+  final String title;
+
+  /// Flat option list (used when [sections] is empty).
+  final List<TvMenuOption> options;
+
+  /// Optional titled groups; when non-empty, rendered instead of [options].
   final List<TvMenuSection> sections;
+
   final VoidCallback onClose;
 
   /// Called on any focus change / selection within the menu, so the host can
@@ -70,7 +82,8 @@ class _TvTrackMenuState extends State<TvTrackMenu> {
 
   @override
   Widget build(BuildContext context) {
-    var optionIndex = 0; // first option overall gets autofocus
+    var optionIndex = 0;
+    final useSections = widget.sections.isNotEmpty;
     return Align(
       alignment: Alignment.centerRight,
       child: FocusScope(
@@ -79,20 +92,14 @@ class _TvTrackMenuState extends State<TvTrackMenu> {
           final k = e.logicalKey;
           // Swallow EVERY phase of Back (down/repeat/up). Closing on the DOWN
           // but letting the UP fall through hands the same press to the system
-          // as a route pop — which then eats the NEXT Back-ladder rung (the
-          // menu closed AND the controls vanished in one press).
+          // as a route pop — which then eats the NEXT Back-ladder rung.
           if (k == LogicalKeyboardKey.goBack ||
               k == LogicalKeyboardKey.escape) {
             if (e is KeyDownEvent) widget.onClose();
             return KeyEventResult.handled;
           }
           if (e is! KeyDownEvent) return KeyEventResult.ignored;
-          // Any key inside the menu counts as activity — resets the host's
-          // inactivity auto-hide even when focus doesn't move (edge Up/Down,
-          // Left/Right) so the menu never closes while the user is interacting.
           widget.onInteract?.call();
-          // Swallow Left/Right so focus can't traverse out of the side panel;
-          // Up/Down fall through to move between rows.
           if (k == LogicalKeyboardKey.arrowLeft ||
               k == LogicalKeyboardKey.arrowRight) {
             return KeyEventResult.handled;
@@ -106,28 +113,47 @@ class _TvTrackMenuState extends State<TvTrackMenu> {
           child: FocusTraversalGroup(
             policy: OrderedTraversalPolicy(),
             child: ListView(
-              padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 20),
+              padding: const EdgeInsets.symmetric(vertical: 28, horizontal: 16),
               children: [
-                for (final s in widget.sections) ...[
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(8, 16, 8, 8),
-                    child: Text(
-                      s.title,
-                      style: const TextStyle(
-                        color: Colors.white54,
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                        letterSpacing: 1.1,
-                      ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 4, 12, 20),
+                  child: Text(
+                    widget.title,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 22,
+                      fontWeight: FontWeight.w700,
                     ),
                   ),
-                  for (final o in s.options)
+                ),
+                if (useSections)
+                  for (final s in widget.sections) ...[
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(12, 12, 12, 6),
+                      child: Text(
+                        s.title,
+                        style: const TextStyle(
+                          color: Colors.white54,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 1.1,
+                        ),
+                      ),
+                    ),
+                    for (final o in s.options)
+                      _Row(
+                        option: o,
+                        autofocus: optionIndex++ == 0,
+                        onInteract: widget.onInteract,
+                      ),
+                  ]
+                else
+                  for (final o in widget.options)
                     _Row(
                       option: o,
                       autofocus: optionIndex++ == 0,
                       onInteract: widget.onInteract,
                     ),
-                ],
               ],
             ),
           ),
@@ -153,6 +179,8 @@ class _RowState extends State<_Row> {
   @override
   Widget build(BuildContext context) {
     final o = widget.option;
+    final trailingColor =
+        _focused ? Colors.white : Colors.white.withValues(alpha: 0.55);
     return Focus(
       autofocus: widget.autofocus,
       onFocusChange: (f) {
@@ -171,30 +199,38 @@ class _RowState extends State<_Row> {
         onTap: o.onSelect,
         child: Container(
           margin: const EdgeInsets.symmetric(vertical: 2),
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
           decoration: BoxDecoration(
-            color: _focused ? Colors.white.withValues(alpha: 0.14) : null,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: _focused ? AppColors.accent : Colors.transparent,
-              width: 2,
-            ),
+            color: _focused ? AppColors.accent : null,
+            borderRadius: BorderRadius.circular(4),
           ),
           child: Row(
             children: [
-              Icon(
-                o.selected ? Icons.check : Icons.circle_outlined,
-                size: 18,
-                color: o.selected ? AppColors.accent : Colors.white38,
-              ),
-              const SizedBox(width: 12),
+              if (o.showCheck) ...[
+                Icon(
+                  o.selected ? Icons.check : Icons.circle_outlined,
+                  size: 18,
+                  color: o.selected
+                      ? (_focused ? Colors.white : AppColors.accent)
+                      : Colors.white38,
+                ),
+                const SizedBox(width: 12),
+              ],
               Expanded(
-                child: Text(o.label,
-                    style: const TextStyle(color: Colors.white, fontSize: 16)),
+                child: Text(
+                  o.label,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
               ),
               if (o.trailing != null)
-                Text(o.trailing!,
-                    style: const TextStyle(color: Colors.white38, fontSize: 13)),
+                Text(
+                  o.trailing!,
+                  style: TextStyle(color: trailingColor, fontSize: 15),
+                ),
             ],
           ),
         ),

--- a/test/features/player/tv_track_helpers_test.dart
+++ b/test/features/player/tv_track_helpers_test.dart
@@ -90,8 +90,17 @@ void main() {
     test('maps known families, null otherwise', () {
       expect(subtitleFontAsset('Inter'), 'assets/fonts/Inter.ttf');
       expect(subtitleFontAsset('Noto Sans'), 'assets/fonts/NotoSans-Regular.ttf');
+      expect(subtitleFontAsset('Poppins'), isNull); // download-on-demand
       expect(subtitleFontAsset(''), isNull);
       expect(subtitleFontAsset('Comic Sans'), isNull);
+    });
+  });
+
+  group('subtitleFontFileName', () {
+    test('maps family to ttf filename', () {
+      expect(subtitleFontFileName('Inter'), 'Inter.ttf');
+      expect(subtitleFontFileName('Poppins'), 'Poppins-Regular.ttf');
+      expect(subtitleFontFileName(''), isNull);
     });
   });
 
@@ -111,20 +120,36 @@ void main() {
   group('captionStyleFromPrefs', () {
     test('maps prefs to style', () {
       final s = captionStyleFromPrefs(
-        scale: 1.3, colorHex: '#FFFFFFFF', bgOpacity: 0.0, position: 95, font: 'Inter');
+        scale: 1.3, colorHex: '#FFFFFFFF', bgOpacity: 0.0, font: 'Inter');
       expect(s.scale, 1.3);
       expect(s.fgColor, 0xFFFFFFFF);
       expect(s.bgColor, 0); // transparent (opacity 0)
       expect(s.edge, isTrue); // outline when no bg box
-      expect(s.position, closeTo(0.05, 0.001)); // (100-95)/100
+      expect(s.edgeType, kTvEdgeOutline);
       expect(s.fontFamily, 'Inter');
     });
     test('background opacity produces alpha-black bg and no edge', () {
       final s = captionStyleFromPrefs(
-        scale: 1.0, colorHex: '#FFFFFFFF', bgOpacity: 1.0, position: 50, font: '');
+        scale: 1.0, colorHex: '#FFFFFFFF', bgOpacity: 1.0, font: '');
       expect(s.bgColor, 0xFF000000);
       expect(s.edge, isFalse);
-      expect(s.position, closeTo(0.5, 0.001));
+      expect(s.edgeType, kTvEdgeNone);
+    });
+    test('explicit outlineType overrides bg heuristic', () {
+      final s = captionStyleFromPrefs(
+        scale: 1.0,
+        colorHex: '#FFFFFFFF',
+        bgOpacity: 0.5,
+        font: '',
+        outlineType: 'shadow',
+      );
+      expect(s.edgeType, kTvEdgeDropShadow);
+      expect(s.edge, isTrue);
+    });
+    test('phone-only outline presets fall back to outline', () {
+      expect(tvEdgeTypeFromOutlinePref('soft'), kTvEdgeOutline);
+      expect(tvEdgeTypeFromOutlinePref('glow'), kTvEdgeOutline);
+      expect(tvEdgeTypeFromOutlinePref('bold'), kTvEdgeOutline);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Reorganize TV Audio & Subs into a Crunchyroll-style Settings list with drill-ins for Audio, Subtitles/CC, Captions Styling, and Volume (Servers/Quality on Flutter)
- Captions Styling: size, color, edge style, background, font, position — live apply on native + Flutter Exo
- Move playback speed out of that menu onto a speedometer pill beside MegaSkip
- Fixes: optimistic subtitle checkmarks, force cue line for Position, filter CEA-608/708 ghost rows, download-on-demand font staging

## Testing
- Settings drill-ins and Back stack (Android TV native player)
- Subtitle Off/track selection checkmarks
- Captions Styling live apply (size, color, edge, background, font, position)
- Speedometer pill and speed menu
- Font download/staging for non-bundled families
- Flutter Exo fallback path covered for the same Settings IA
- Unit tests: `tv_track_helpers_test`, `tv_track_menu_test`

Closes #48

## Screenshots
<img width="3232" height="1816" alt="CleanShot 2026-08-26 at 09 53 40@2x" src="https://github.com/user-attachments/assets/55ef461a-08b5-4a0a-9d1f-f9f22738820b" />

<img width="3234" height="1814" alt="CleanShot 2026-08-26 at 09 54 13@2x" src="https://github.com/user-attachments/assets/9585079d-114a-4997-9a96-61d711205d2b" />

### Speed Options
<img width="3242" height="1824" alt="CleanShot 2026-08-26 at 09 54 36@2x" src="https://github.com/user-attachments/assets/d43ecca6-b7ee-4d55-b3b4-b65641391c41" />
<img width="3224" height="1824" alt="CleanShot 2026-08-26 at 09 54 56@2x" src="https://github.com/user-attachments/assets/58efb7b7-4df6-4f5d-9cbd-c16d25981abf" />


