### PR TITLE
feat(tv): 50-episode range grouping on TV detail and player

### DIFF
--- a/android/app/src/main/kotlin/com/spyou/watch_app/LockedScrollView.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/LockedScrollView.kt
@@ -1,0 +1,43 @@
+package com.spyou.watch_app
+
+import android.content.Context
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.view.View
+import android.widget.ScrollView
+
+/**
+ * ScrollView that can refuse to scroll — used for the TV player side panel so
+ * the "Episodes" header and range rail stay pinned while an inner list scrolls.
+ */
+class LockedScrollView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : ScrollView(context, attrs) {
+
+    /** When true, focus changes won't move this scroll view. */
+    var scrollLocked: Boolean = false
+
+    private var ignoreScrollLock = false
+
+    /** Position the rail without letting focus-driven scroll fight it. */
+    fun scrollToIgnoringLock(x: Int, y: Int) {
+        ignoreScrollLock = true
+        super.scrollTo(x, y)
+        ignoreScrollLock = false
+    }
+
+    override fun requestChildRectangleOnScreen(
+        child: View,
+        rectangle: Rect,
+        immediate: Boolean,
+    ): Boolean {
+        if (scrollLocked) return false
+        return super.requestChildRectangleOnScreen(child, rectangle, immediate)
+    }
+
+    override fun scrollTo(x: Int, y: Int) {
+        if (scrollLocked && !ignoreScrollLock) return
+        super.scrollTo(x, y)
+    }
+}

--- a/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.view.Gravity
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.SoundEffectConstants
@@ -118,6 +119,9 @@ class TvPlayerActivity : Activity() {
         private const val HOLD_MS = 500L
         private const val DEFAULT_ACCENT = 0xFFFF4D5E.toInt()
         private const val UNFOCUSED_PILL = 0x59101014 // subtle dark glass (premium)
+        /** CloudStream-style chunk size — matches Dart [kEpisodeRangeChunk]. */
+        private const val EPISODE_RANGE_CHUNK = 50
+        private const val RANGE_CHIP_SURFACE = 0xFF2A2A32.toInt()
 
         /** Foreground native player, so Dart can push late filler info. */
         @JvmStatic
@@ -226,6 +230,7 @@ class TvPlayerActivity : Activity() {
     private var scrubbing = false
     private var speedEngaged = false
     private var menuOpen = false
+    private var episodeRangeIndex = 0 // 50-ep chunk in the Episodes panel
     private var menuOpener: View? = null // the row button that opened the panel
     // Land focus on the option the user last picked (else the current selection,
     // else the first row) when a menu (re)opens — not always the first row.
@@ -791,6 +796,38 @@ class TvPlayerActivity : Activity() {
     }
 
     // ── Options menu (Quality / Audio / Subtitles / Speed / Volume) ───────────
+    private fun resetMenuPanelLayout() {
+        val scroll = menuPanel as? LockedScrollView ?: return
+        scroll.scrollLocked = false
+        scroll.isFillViewport = false
+        menuContent.layoutParams = menuContent.layoutParams.apply {
+            height = android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+        }
+    }
+
+    /** Header + range rail stay fixed; only the inner episode list scrolls. */
+    private fun prepareEpisodesPanelLayout() {
+        val scroll = menuPanel as? LockedScrollView ?: return
+        scroll.scrollLocked = true
+        scroll.isFillViewport = true
+        scroll.scrollTo(0, 0)
+        menuContent.layoutParams = menuContent.layoutParams.apply {
+            height = android.view.ViewGroup.LayoutParams.MATCH_PARENT
+        }
+    }
+
+    private fun episodeListScroll(): android.widget.ScrollView =
+        android.widget.ScrollView(this).apply {
+            tag = "episode-list-scroll"
+            layoutParams = android.widget.LinearLayout.LayoutParams(
+                android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                0,
+                1f,
+            )
+            isVerticalScrollBarEnabled = false
+            overScrollMode = View.OVER_SCROLL_NEVER
+        }
+
     private fun showPanel() {
         // Hide the transport controls so the panel reads cleanly over the video.
         controls.visibility = View.GONE
@@ -814,6 +851,7 @@ class TvPlayerActivity : Activity() {
             avMenuActive = false
             avStack.clear()
         }
+        resetMenuPanelLayout()
         menuContent.removeAllViews()
         build()
         showPanel()
@@ -835,19 +873,312 @@ class TvPlayerActivity : Activity() {
         focusTarget = null
         avMenuActive = false
         avStack.clear()
+        episodeRangeIndex = if (episodeCount > 0) currentIndex / EPISODE_RANGE_CHUNK else 0
+        buildEpisodesPanel()
+        showPanel()
+        menuContent.post { focusEpisodeMenuTarget() }
+    }
+
+    private fun episodeRangeCount(): Int =
+        if (episodeCount <= 0) 0
+        else (episodeCount + EPISODE_RANGE_CHUNK - 1) / EPISODE_RANGE_CHUNK
+
+    private fun episodeDisplayNumber(index: Int): Int {
+        val label = episodeLabels.getOrNull(index) ?: return index + 1
+        val m = Regex("""Episode\s+(\d+)""", RegexOption.IGNORE_CASE).find(label)
+        return m?.groupValues?.get(1)?.toIntOrNull() ?: (index + 1)
+    }
+
+    private fun episodeRangeLabel(rangeIndex: Int): String {
+        if (episodeCount == 0) return ""
+        val startIdx = (rangeIndex * EPISODE_RANGE_CHUNK).coerceIn(0, episodeCount - 1)
+        val endIdx = ((rangeIndex + 1) * EPISODE_RANGE_CHUNK - 1).coerceIn(0, episodeCount - 1)
+        return "${episodeDisplayNumber(startIdx)}–${episodeDisplayNumber(endIdx)}"
+    }
+
+    private fun buildEpisodesPanel() {
         menuContent.removeAllViews()
+        resetMenuPanelLayout()
+        prepareEpisodesPanelLayout()
         sectionHeader("Episodes")
-        for (i in 0 until episodeCount) {
+        val rangeCount = episodeRangeCount()
+        if (rangeCount <= 1) {
+            val listScroll = episodeListScroll()
+            val list = android.widget.LinearLayout(this).apply {
+                orientation = android.widget.LinearLayout.VERTICAL
+                layoutParams = android.widget.FrameLayout.LayoutParams(
+                    android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                    android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+                )
+            }
+            addEpisodeRows(0, episodeCount, list)
+            listScroll.addView(list)
+            menuContent.addView(listScroll)
+            return
+        }
+        episodeRangeIndex = episodeRangeIndex.coerceIn(0, rangeCount - 1)
+        val start = episodeRangeIndex * EPISODE_RANGE_CHUNK
+        val end = minOf(start + EPISODE_RANGE_CHUNK, episodeCount)
+
+        // Pin the range rail on the left; only the episode list scrolls.
+        val body = android.widget.LinearLayout(this).apply {
+            orientation = android.widget.LinearLayout.HORIZONTAL
+            gravity = Gravity.TOP
+            layoutParams = android.widget.LinearLayout.LayoutParams(
+                android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                0,
+                1f,
+            )
+        }
+
+        val rail = android.widget.LinearLayout(this).apply {
+            orientation = android.widget.LinearLayout.VERTICAL
+            layoutParams = android.widget.LinearLayout.LayoutParams(
+                dp(96),
+                android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+            ).apply {
+                marginEnd = dp(12)
+                gravity = Gravity.TOP
+            }
+        }
+        for (r in 0 until rangeCount) {
+            rail.addView(
+                rangeChip(
+                    rangeIndex = r,
+                    label = episodeRangeLabel(r),
+                    selected = r == episodeRangeIndex,
+                ) {
+                    if (r != episodeRangeIndex) {
+                        episodeRangeIndex = r
+                        firstSelectedRow = null
+                        focusTarget = null
+                        buildEpisodesPanel()
+                        menuContent.post { focusEpisodeMenuTarget(preferRange = true) }
+                    }
+                },
+            )
+            if (r < rangeCount - 1) {
+                rail.addView(
+                    View(this).apply {
+                        layoutParams = android.widget.LinearLayout.LayoutParams(
+                            android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                            dp(8),
+                        )
+                    },
+                )
+            }
+        }
+
+        // Many ranges (>~700 eps): rail gets its own locked scroll — stays put
+        // while browsing episodes; unlock only when a chip holds focus.
+        val railContainer: View = if (rangeCount > 14) {
+            LockedScrollView(this).apply {
+                tag = "range-rail-scroll"
+                scrollLocked = true
+                layoutParams = android.widget.LinearLayout.LayoutParams(
+                    dp(96),
+                    android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                ).apply { marginEnd = dp(12) }
+                isVerticalScrollBarEnabled = false
+                overScrollMode = View.OVER_SCROLL_NEVER
+                isFocusable = false
+                addView(
+                    rail.apply {
+                        layoutParams = android.widget.FrameLayout.LayoutParams(
+                            android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                            android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+                        )
+                    },
+                )
+            }
+        } else {
+            rail
+        }
+        body.addView(railContainer)
+
+        val listScroll = episodeListScroll().apply {
+            layoutParams = android.widget.LinearLayout.LayoutParams(
+                0,
+                android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                1f,
+            )
+        }
+        val list = android.widget.LinearLayout(this).apply {
+            orientation = android.widget.LinearLayout.VERTICAL
+            layoutParams = android.widget.FrameLayout.LayoutParams(
+                android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+        }
+        addEpisodeRows(start, end, list)
+        listScroll.addView(list)
+        body.addView(listScroll)
+        menuContent.addView(body)
+        scrollRangeRailToSelected()
+    }
+
+    private fun rangeRailScroll(): LockedScrollView? =
+        menuContent.findViewWithTag("range-rail-scroll") as? LockedScrollView
+
+    private fun setRangeRailLocked(locked: Boolean) {
+        rangeRailScroll()?.scrollLocked = locked
+    }
+
+    private fun scrollRangeRailToSelected() {
+        val scroll = rangeRailScroll() ?: return
+        val chip = menuContent.findViewWithTag<View>("range-$episodeRangeIndex") ?: return
+        scroll.post { scroll.scrollToIgnoringLock(0, chip.top.coerceAtLeast(0)) }
+    }
+
+    private fun addEpisodeRows(
+        from: Int,
+        until: Int,
+        parent: android.widget.LinearLayout,
+    ) {
+        for (i in from until until) {
             val label = episodeLabels.getOrNull(i) ?: "Episode ${i + 1}"
             val isFiller = i < fillerFlags.size && fillerFlags[i]
-            val row = if (isFiller) "$label  · FILLER" else label
-            option(row, selected = i == currentIndex) { if (i != currentIndex) loadEpisode(i) }
+            val rowLabel = if (isFiller) "$label  · FILLER" else label
+            episodeOption(parent, i, rowLabel, selected = i == currentIndex) {
+                if (i != currentIndex) loadEpisode(i)
+            }
         }
-        showPanel()
-        // Land focus on the current episode (row index = currentIndex + 1 header).
-        menuContent.post {
-            val row = (currentIndex + 1).coerceIn(0, menuContent.childCount - 1)
-            menuContent.getChildAt(row)?.requestFocus()
+    }
+
+    private fun rangeChip(
+        rangeIndex: Int,
+        label: String,
+        selected: Boolean,
+        onSelect: () -> Unit,
+    ): TextView {
+        return TextView(this).apply {
+            tag = "range-$rangeIndex"
+            text = label
+            textSize = 13f
+            gravity = Gravity.CENTER
+            isFocusable = true
+            isFocusableInTouchMode = true
+            minHeight = dp(32)
+            setPadding(dp(10), dp(8), dp(10), dp(8))
+            setTextColor(if (selected) android.graphics.Color.WHITE else 0xFFE8E8EC.toInt())
+            if (selected) setTypeface(typeface, android.graphics.Typeface.BOLD)
+            background = rangeChipBg(selected, focused = false)
+            onFocusChangeListener = View.OnFocusChangeListener { v, has ->
+                if (has) setRangeRailLocked(false)
+                v.background = rangeChipBg(selected, has)
+                (v as TextView).setTextColor(
+                    if (has || selected) android.graphics.Color.WHITE else 0xFFE8E8EC.toInt(),
+                )
+            }
+            bindSingleTapActivate { onSelect() }
+            setOnKeyListener { _, keyCode, event ->
+                if (event.action != KeyEvent.ACTION_DOWN) return@setOnKeyListener false
+                if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                    focusEpisodeFromRangeChip()
+                    true
+                } else false
+            }
+        }
+    }
+
+    private fun focusSelectedRangeChip() {
+        menuContent.findViewWithTag<View>("range-$episodeRangeIndex")?.requestFocus()
+    }
+
+    private fun focusEpisodeFromRangeChip() {
+        val rangeStart = episodeRangeIndex * EPISODE_RANGE_CHUNK
+        val rangeEnd = minOf(rangeStart + EPISODE_RANGE_CHUNK, episodeCount)
+        val target = if (currentIndex in rangeStart until rangeEnd) {
+            currentIndex
+        } else {
+            rangeStart
+        }
+        val row = menuContent.findViewWithTag<View>("ep-$target")
+        row?.requestFocus()
+        row?.let { scrollEpisodeIntoView(it) }
+    }
+
+    private fun rangeChipBg(selected: Boolean, focused: Boolean): android.graphics.drawable.GradientDrawable {
+        return android.graphics.drawable.GradientDrawable().apply {
+            cornerRadius = dp(20).toFloat()
+            setColor(if (selected) accent else RANGE_CHIP_SURFACE)
+            if (focused) setStroke(dp(2), android.graphics.Color.WHITE)
+        }
+    }
+
+    private fun episodeOption(
+        parent: android.widget.LinearLayout,
+        index: Int,
+        label: String,
+        selected: Boolean,
+        onSelect: () -> Unit,
+    ) {
+        val row = TextView(this).apply {
+            tag = "ep-$index"
+            text = (if (selected) "✓   " else "     ") + label
+            setTextColor(if (selected) android.graphics.Color.WHITE else 0xFFB6B6C0.toInt())
+            textSize = 16.5f
+            maxLines = 1
+            ellipsize = android.text.TextUtils.TruncateAt.END
+            if (selected) setTypeface(typeface, android.graphics.Typeface.BOLD)
+            isFocusable = true
+            setPadding(dp(16), dp(11), dp(16), dp(11))
+            background = pillBg(0x00000000)
+            onFocusChangeListener = View.OnFocusChangeListener { v, has ->
+                if (has) setRangeRailLocked(true)
+                v.background = pillBg(if (has) accent else 0x00000000)
+                (v as TextView).setTextColor(
+                    if (has) android.graphics.Color.WHITE
+                    else if (selected) android.graphics.Color.WHITE else 0xFFB6B6C0.toInt(),
+                )
+            }
+            bindSingleTapActivate {
+                lastFocusLabel = label
+                onSelect()
+                closeMenu()
+            }
+            setOnKeyListener { _, keyCode, event ->
+                if (event.action != KeyEvent.ACTION_DOWN) return@setOnKeyListener false
+                if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT &&
+                    episodeRangeCount() > 1
+                ) {
+                    focusSelectedRangeChip()
+                    true
+                } else false
+            }
+        }
+        if (selected && firstSelectedRow == null) firstSelectedRow = row
+        if (label == lastFocusLabel) focusTarget = row
+        parent.addView(
+            row,
+            android.widget.LinearLayout.LayoutParams(
+                android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+            ),
+        )
+    }
+
+    private fun focusEpisodeMenuTarget(preferRange: Boolean = false) {
+        if (preferRange) {
+            menuContent.findViewWithTag<TextView>("range-$episodeRangeIndex")?.requestFocus()
+            return
+        }
+        val target = menuContent.findViewWithTag<View>("ep-$currentIndex")
+        target?.requestFocus()
+        target?.let { scrollEpisodeIntoView(it) }
+            ?: firstSelectedRow?.requestFocus()
+            ?: firstFocusable(menuContent)?.requestFocus()
+    }
+
+    private fun scrollEpisodeIntoView(row: View) {
+        var parent = row.parent
+        while (parent != null) {
+            if (parent is android.widget.ScrollView && parent.tag == "episode-list-scroll") {
+                val scroll = parent
+                scroll.post { scroll.smoothScrollTo(0, row.top) }
+                return
+            }
+            parent = (parent as? View)?.parent
         }
     }
 
@@ -857,6 +1188,7 @@ class TvPlayerActivity : Activity() {
         avStack.clear()
         menuPanel.visibility = View.GONE
         menuContent.removeAllViews()
+        resetMenuPanelLayout()
         bumpControls()
         (menuOpener ?: root).requestFocus()
     }

--- a/android/app/src/main/res/layout/tv_player.xml
+++ b/android/app/src/main/res/layout/tv_player.xml
@@ -18,10 +18,10 @@
 
     <!-- Right-side options menu (Settings / Episodes / Speed / …).
          Populated + driven by the Activity; native focus handles D-pad. -->
-    <ScrollView android:id="@+id/menu_panel" android:layout_width="452dp" android:layout_height="match_parent" android:layout_gravity="end" android:background="#F00C0C10" android:paddingHorizontal="30dp" android:paddingVertical="34dp" android:scrollbars="none" android:visibility="gone">
+    <com.spyou.watch_app.LockedScrollView android:id="@+id/menu_panel" android:layout_width="520dp" android:layout_height="match_parent" android:layout_gravity="end" android:background="#A80C0C10" android:paddingHorizontal="30dp" android:paddingVertical="34dp" android:scrollbars="none" android:visibility="gone">
 
         <LinearLayout android:id="@+id/menu_content" android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical" />
-    </ScrollView>
+    </com.spyou.watch_app.LockedScrollView>
 
     <!-- Controls overlay — toggled GONE/VISIBLE by the Activity, auto-hides. -->
     <FrameLayout android:id="@+id/controls" android:layout_width="match_parent" android:layout_height="match_parent" android:clipChildren="false" android:clipToPadding="false" android:visibility="gone">

--- a/lib/core/tv/tv_episode_range_chips.dart
+++ b/lib/core/tv/tv_episode_range_chips.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_text.dart';
+import 'tv_focusable.dart';
+
+/// D-pad focusable episode-range chips (`1–50`, `51–100`, …).
+///
+/// [axis] is [Axis.horizontal] for the detail tab row, or [Axis.vertical]
+/// for the player overlay's left rail.
+class TvEpisodeRangeChips extends StatelessWidget {
+  const TvEpisodeRangeChips({
+    super.key,
+    required this.count,
+    required this.selected,
+    required this.labelFor,
+    required this.onSelect,
+    this.axis = Axis.horizontal,
+    this.selectedChipFocusNode,
+    this.episodeReturnFocusNode,
+  });
+
+  final int count;
+  final int selected;
+  final String Function(int) labelFor;
+  final ValueChanged<int> onSelect;
+  final Axis axis;
+
+  /// When set, wired to the selected chip so callers can focus it from the
+  /// episode list (◀ enters the rail on the active range, not the first).
+  final FocusNode? selectedChipFocusNode;
+
+  /// When set, ◀▶ from a chip returns focus to the episode list (usually the
+  /// current episode row).
+  final FocusNode? episodeReturnFocusNode;
+
+  static const double _chipHeight = 32;
+  static const double _chipRadius = 20;
+
+  @override
+  Widget build(BuildContext context) {
+    if (count <= 1) return const SizedBox.shrink();
+
+    final list = ListView.separated(
+      primary: false,
+      scrollDirection: axis,
+      padding: axis == Axis.horizontal
+          ? const EdgeInsets.symmetric(horizontal: 16)
+          : const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+      itemCount: count,
+      separatorBuilder: (_, _) => axis == Axis.horizontal
+          ? const SizedBox(width: 8)
+          : const SizedBox(height: 8),
+      itemBuilder: (_, i) => _chip(i),
+    );
+
+    return axis == Axis.horizontal
+        ? SizedBox(height: 48, child: list)
+        : SizedBox(
+            width: 96,
+            child: list,
+          );
+  }
+
+  Widget _chip(int i) {
+    final label = labelFor(i);
+    final isSelected = i == selected;
+    final chip = TvFocusable(
+      key: ValueKey('tv-range-$i'),
+      variant: TvFocusVariant.box,
+      scale: 1.0,
+      borderRadius: _chipRadius,
+      focusNode: isSelected ? selectedChipFocusNode : null,
+      onTap: () => onSelect(i),
+      semanticLabel: label,
+      builder: (_) => Container(
+        height: _chipHeight,
+        constraints: axis == Axis.horizontal
+            ? const BoxConstraints(minWidth: 72)
+            : const BoxConstraints(minWidth: 80),
+        padding: const EdgeInsets.symmetric(horizontal: 14),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: isSelected ? AppColors.accent : AppColors.surface2,
+          borderRadius: BorderRadius.circular(_chipRadius),
+        ),
+        child: Text(
+          label,
+          textAlign: TextAlign.center,
+          style: AppText.caption.copyWith(
+            color: isSelected ? Colors.white : AppColors.textPrimary,
+            fontWeight: FontWeight.w600,
+            height: 1.0,
+          ),
+        ),
+      ),
+    );
+    final returnFocus = episodeReturnFocusNode;
+    if (returnFocus == null) return chip;
+    return Focus(
+      onKeyEvent: (_, event) {
+        if (event is KeyDownEvent &&
+            event.logicalKey == LogicalKeyboardKey.arrowRight) {
+          returnFocus.requestFocus();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: chip,
+    );
+  }
+}

--- a/lib/features/detail/detail_episodes.dart
+++ b/lib/features/detail/detail_episodes.dart
@@ -86,10 +86,6 @@ class _EpisodesTab extends StatefulWidget {
 }
 
 class _EpisodesTabState extends State<_EpisodesTab> {
-  /// Long seasons are split into chunks of this size (CloudStream-style) so
-  /// hundreds/thousands of episodes stay navigable via range chips.
-  static const int _chunk = 50;
-
   bool _grid = false;
 
   /// Selected scanlation group, or null for "All". Several groups release the
@@ -124,10 +120,10 @@ class _EpisodesTabState extends State<_EpisodesTab> {
     // Against the FILTERED list — the range index addresses what's on screen,
     // and a scanlator filter makes that a different list to seasonEps.
     final local = _filteredEps.indexOf(resumeEp);
-    return local < 0 ? 0 : local ~/ _chunk;
+    return episodeRangeIndex(local);
   }
 
-  int get _rangeCount => (_filteredEps.length / _chunk).ceil();
+  int get _rangeCount => episodeRangeCount(_filteredEps.length);
 
   /// Scanlation groups on offer, first-seen order (which is the source's own
   /// ordering, so the group a reader is following tends to come first).
@@ -150,9 +146,6 @@ class _EpisodesTabState extends State<_EpisodesTab> {
         if (e.scanlator?.trim() == want) e,
     ];
   }
-
-  String _numLabel(Episode e, int fallback) =>
-      (e.number?.toInt() ?? fallback).toString();
 
   /// Reading progress lives in [ReadStore] (page index / scroll permille),
   /// keyed by showId — the video [ResumeStore] never holds a mark for a
@@ -230,7 +223,7 @@ class _EpisodesTabState extends State<_EpisodesTab> {
     if (local < 0 && n >= 1 && n <= eps.length) local = n - 1;
     if (local < 0) return;
     setState(() {
-      _rangeIndex = local ~/ _chunk;
+      _rangeIndex = episodeRangeIndex(local);
       _grid = true; // the grid makes the jumped-to episode easy to spot
       _highlightEpId = eps[local].id;
     });
@@ -251,9 +244,8 @@ class _EpisodesTabState extends State<_EpisodesTab> {
     // index past the end, so clamp before slicing.
     final maxRange = _rangeCount == 0 ? 0 : _rangeCount - 1;
     final rangeIndex = _rangeIndex.clamp(0, maxRange);
-    final start = (rangeIndex * _chunk).clamp(0, total);
-    final end = (start + _chunk).clamp(0, total);
-    final visible = eps.sublist(start, end);
+    final slice = episodeRangeSlice(rangeIndex, total);
+    final visible = eps.sublist(slice.start, slice.end);
     final showRanges = _rangeCount > 1;
     final groups = _scanlators;
 
@@ -328,12 +320,7 @@ class _EpisodesTabState extends State<_EpisodesTab> {
             child: _RangeChips(
               count: _rangeCount,
               selected: rangeIndex,
-              labelFor: (i) {
-                final s = (i * _chunk).clamp(0, total - 1);
-                final e = ((i + 1) * _chunk - 1).clamp(0, total - 1);
-                return '${_numLabel(eps[s], s + 1)}'
-                    '–${_numLabel(eps[e], e + 1)}';
-              },
+              labelFor: (i) => episodeRangeLabel(eps, i),
               onSelect: (i) => setState(() {
                 _rangeIndex = i;
                 _highlightEpId = null;
@@ -341,9 +328,9 @@ class _EpisodesTabState extends State<_EpisodesTab> {
             ),
           ),
         if (_grid)
-          _buildGrid(store, visible, start)
+          _buildGrid(store, visible, slice.start)
         else
-          _buildList(store, visible, start),
+          _buildList(store, visible, slice.start),
         const SliverToBoxAdapter(child: SizedBox(height: 48)),
       ],
     );

--- a/lib/features/detail/detail_screen_tv.dart
+++ b/lib/features/detail/detail_screen_tv.dart
@@ -70,10 +70,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
           onSubmitted: (q) => Navigator.pop(ctx, q),
         ),
         actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, ''),
-            child: const Text('Clear'),
-          ),
+          TextButton(onPressed: () => Navigator.pop(ctx, ''), child: const Text('Clear')),
           TextButton(
             onPressed: () => Navigator.pop(ctx, ctrl.text),
             style: TextButton.styleFrom(foregroundColor: AppColors.accent),
@@ -97,12 +94,8 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
   late bool _inMyList;
 
   // ── Left ↔ Right focus bridge ─────────────────────────────────────────────
-  final FocusScopeNode _leftScope = FocusScopeNode(
-    debugLabel: 'tv-detail-left',
-  );
-  final FocusScopeNode _rightScope = FocusScopeNode(
-    debugLabel: 'tv-detail-right',
-  );
+  final FocusScopeNode _leftScope = FocusScopeNode(debugLabel: 'tv-detail-left');
+  final FocusScopeNode _rightScope = FocusScopeNode(debugLabel: 'tv-detail-right');
 
   @override
   void initState() {
@@ -110,10 +103,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     _status = _listStatus.statusOf(widget.item);
     _inMyList = _status != null || _myList.contains(widget.item);
     if (sl.isRegistered<DiscordRpc>()) {
-      sl<DiscordRpc>().setBrowsing(
-        title: widget.item.title,
-        posterUrl: widget.item.cover,
-      );
+      sl<DiscordRpc>().setBrowsing(title: widget.item.title, posterUrl: widget.item.cover);
     }
   }
 
@@ -127,16 +117,12 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
 
   // D-pad RIGHT from the left pane → move into the right pane.
   KeyEventResult _onLeftKey(FocusNode _, KeyEvent event) {
-    if (event is KeyDownEvent &&
-        event.logicalKey == LogicalKeyboardKey.arrowRight) {
+    if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowRight) {
       final last = _rightScope.focusedChild;
       if (last != null) {
         last.requestFocus();
       } else {
-        _rightScope.traversalDescendants
-            .where((n) => n.canRequestFocus)
-            .firstOrNull
-            ?.requestFocus();
+        _rightScope.traversalDescendants.where((n) => n.canRequestFocus).firstOrNull?.requestFocus();
       }
       return KeyEventResult.handled;
     }
@@ -146,13 +132,8 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
   // D-pad LEFT from the right pane: try intra-pane traversal first; only
   // cross to the left pane when already at the left edge.
   KeyEventResult _onRightKey(FocusNode _, KeyEvent event) {
-    if (event is KeyDownEvent &&
-        event.logicalKey == LogicalKeyboardKey.arrowLeft) {
-      final moved =
-          FocusManager.instance.primaryFocus?.focusInDirection(
-            TraversalDirection.left,
-          ) ??
-          false;
+    if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+      final moved = FocusManager.instance.primaryFocus?.focusInDirection(TraversalDirection.left) ?? false;
       if (!moved) _leftScope.requestFocus();
       return KeyEventResult.handled;
     }
@@ -168,11 +149,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
       if (mark != null) highestMarked = j;
     }
     if (highestMarked == null) return 0;
-    final mark = store.get(
-      widget.item.sourceId,
-      widget.item.url,
-      eps[highestMarked].id,
-    )!;
+    final mark = store.get(widget.item.sourceId, widget.item.url, eps[highestMarked].id)!;
     if (!mark.finished) return highestMarked;
     if (highestMarked + 1 < eps.length) return highestMarked + 1;
     return highestMarked;
@@ -183,9 +160,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
   ({int index, bool hasResume}) _resumeTarget(List<Episode> eps) {
     if (eps.isEmpty) return (index: 0, hasResume: false);
     final store = sl<ResumeStore>();
-    final hasLocal = eps.any(
-      (e) => store.get(widget.item.sourceId, widget.item.url, e.id) != null,
-    );
+    final hasLocal = eps.any((e) => store.get(widget.item.sourceId, widget.item.url, e.id) != null);
     if (hasLocal) return (index: _resumeIndex(eps), hasResume: true);
     final p = _trackerProgress;
     if (p != null && p > 0 && seasonsOf(eps).length <= 1) {
@@ -198,28 +173,13 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
   }
 
   // ── Player launch (mirrors _DetailViewState._openPlayer exactly) ──────────
-  Future<void> _openPlayer(
-    List<Episode> episodes,
-    int index,
-    MediaDetail detail,
-    String category,
-  ) async {
-    final available = <String>[
-      if ((detail.subCount ?? 0) > 0) 'sub',
-      if ((detail.dubCount ?? 0) > 0) 'dub',
-    ];
+  Future<void> _openPlayer(List<Episode> episodes, int index, MediaDetail detail, String category) async {
+    final available = <String>[if ((detail.subCount ?? 0) > 0) 'sub', if ((detail.dubCount ?? 0) > 0) 'dub'];
     final availableCategories = available.isEmpty ? [category] : available;
     final preferred =
-        sl<TitlePrefsStore>().category(widget.item.sourceId, widget.item.url) ??
-        sl<PlaybackPrefs>().defaultCategory;
-    final launchCategory = availableCategories.contains(preferred)
-        ? preferred
-        : category;
-    resolveSources(String u) => sl<SourceRepository>().sources(
-      u,
-      sourceId: widget.item.sourceId,
-      fast: true,
-    );
+        sl<TitlePrefsStore>().category(widget.item.sourceId, widget.item.url) ?? sl<PlaybackPrefs>().defaultCategory;
+    final launchCategory = availableCategories.contains(preferred) ? preferred : category;
+    resolveSources(String u) => sl<SourceRepository>().sources(u, sourceId: widget.item.sourceId, fast: true);
     // Beta: fully-native TV player (real-window SurfaceView) for TVs that
     // black-screen the Flutter platform-view player. Opt-in; phone unaffected.
     if (sl<PlaybackPrefs>().nativeTvPlayer) {
@@ -260,9 +220,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
           category: launchCategory,
           availableCategories: availableCategories,
           malId: detail.malId ?? widget.item.malId,
-          scrobbleTitle: detail.type == ProviderType.anime
-              ? detail.title
-              : null,
+          scrobbleTitle: detail.type == ProviderType.anime ? detail.title : null,
           tmdbId: detail.tmdbId ?? widget.item.tmdbId,
           tmdbIsTv: detail.tmdbIsTv,
           imdbId: detail.imdbId ?? widget.item.imdbId,
@@ -303,8 +261,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     final hub = sl<TrackerHub>();
     if (!hub.anyConnected) return;
     final isAnime = detail.type == ProviderType.anime;
-    final pins = sl<TrackerBindingStore>()
-        .get(TrackerBindingStore.keyOf(widget.item.sourceId, widget.item.url));
+    final pins = sl<TrackerBindingStore>().get(TrackerBindingStore.keyOf(widget.item.sourceId, widget.item.url));
     hub
         .fetchEntry(
           malId: detail.malId ?? widget.item.malId,
@@ -315,13 +272,13 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
           pinnedIds: pins.isEmpty ? null : pins,
         )
         .then((e) {
-      if (!mounted) return;
-      final p = e?.progress;
-      setState(() {
-        _tracked = e?.onList ?? false;
-        if (p != null && p > 0) _trackerProgress = p;
-      });
-    });
+          if (!mounted) return;
+          final p = e?.progress;
+          setState(() {
+            _tracked = e?.onList ?? false;
+            if (p != null && p > 0) _trackerProgress = p;
+          });
+        });
   }
 
   /// Whether the Tracking action should show — same rule as the phone view: a
@@ -332,8 +289,8 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     if (!hub.anyConnected) return false;
     if (detail.type == ProviderType.anime) return true;
     final simklOn = hub.connected.any((t) => t.displayName == 'Simkl');
-    final hasId = (detail.tmdbId ?? widget.item.tmdbId) != null ||
-        ((detail.imdbId ?? widget.item.imdbId)?.isNotEmpty ?? false);
+    final hasId =
+        (detail.tmdbId ?? widget.item.tmdbId) != null || ((detail.imdbId ?? widget.item.imdbId)?.isNotEmpty ?? false);
     return simklOn && hasId;
   }
 
@@ -347,10 +304,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
       tmdbId: detail.tmdbId ?? widget.item.tmdbId,
       tmdbIsTv: detail.tmdbIsTv,
       imdbId: detail.imdbId ?? widget.item.imdbId,
-      bindingKey: TrackerBindingStore.keyOf(
-        widget.item.sourceId,
-        widget.item.url,
-      ),
+      bindingKey: TrackerBindingStore.keyOf(widget.item.sourceId, widget.item.url),
     );
     if (applied != null && mounted && applied > (_trackerProgress ?? 0)) {
       setState(() => _trackerProgress = applied);
@@ -374,52 +328,33 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
       return;
     }
     if (total == 1) {
-      await _pickSourceAndDownload(
-        episodesBySeason.values.first.first,
-        detail,
-        category,
-      );
+      await _pickSourceAndDownload(episodesBySeason.values.first.first, detail, category);
       return;
     }
-    final availableCategories = <String>[
-      if ((detail.subCount ?? 0) > 0) 'sub',
-      if ((detail.dubCount ?? 0) > 0) 'dub',
-    ];
-    final res =
-        await showModalBottomSheet<
-          ({String quality, String category, List<Episode> episodes})
-        >(
-          context: context,
-          backgroundColor: AppColors.surface,
-          isScrollControlled: true,
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-          ),
-          builder: (_) => _DownloadSheet(
-            title: detail.title,
-            episodesBySeason: episodesBySeason,
-            initialSeason: initialSeason,
-            initialCategory: category,
-            availableCategories: availableCategories,
-            coverUrl: detail.cover ?? widget.item.cover ?? '',
-            coverHeaders: detail.coverHeaders ?? widget.item.coverHeaders,
-            resolve: (ep) => sl<SourceRepository>().sources(
-              ep.url,
-              sourceId: widget.item.sourceId,
-            ),
-            resolveEpisodes: _episodesByCategory,
-          ),
-        );
+    final availableCategories = <String>[if ((detail.subCount ?? 0) > 0) 'sub', if ((detail.dubCount ?? 0) > 0) 'dub'];
+    final res = await showModalBottomSheet<({String quality, String category, List<Episode> episodes})>(
+      context: context,
+      backgroundColor: AppColors.surface,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(20))),
+      builder: (_) => _DownloadSheet(
+        title: detail.title,
+        episodesBySeason: episodesBySeason,
+        initialSeason: initialSeason,
+        initialCategory: category,
+        availableCategories: availableCategories,
+        coverUrl: detail.cover ?? widget.item.cover ?? '',
+        coverHeaders: detail.coverHeaders ?? widget.item.coverHeaders,
+        resolve: (ep) => sl<SourceRepository>().sources(ep.url, sourceId: widget.item.sourceId),
+        resolveEpisodes: _episodesByCategory,
+      ),
+    );
     if (res == null || !mounted) return;
     _startDownload(detail, res.category, res.quality, res.episodes);
   }
 
   Future<Map<int, List<Episode>>> _episodesByCategory(String category) async {
-    final d = await sl<SourceRepository>().detail(
-      widget.item.url,
-      category: category,
-      sourceId: widget.item.sourceId,
-    );
+    final d = await sl<SourceRepository>().detail(widget.item.url, category: category, sourceId: widget.item.sourceId);
     final byS = <int, List<Episode>>{};
     for (final e in d.episodes) {
       (byS[seasonOf(e) ?? 1] ??= <Episode>[]).add(e);
@@ -428,28 +363,18 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     return byS;
   }
 
-  Future<void> _pickSourceAndDownload(
-    Episode ep,
-    MediaDetail detail,
-    String category,
-  ) async {
+  Future<void> _pickSourceAndDownload(Episode ep, MediaDetail detail, String category) async {
     final item = widget.item;
-    final res =
-        await showModalBottomSheet<
-          ({VideoSource chosen, List<VideoSource> all})
-        >(
-          context: context,
-          backgroundColor: AppColors.surface,
-          isScrollControlled: true,
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-          ),
-          builder: (_) => _SourcePickerSheet(
-            title: ep.title.trim().isNotEmpty ? ep.title : detail.title,
-            resolve: () =>
-                sl<SourceRepository>().sources(ep.url, sourceId: item.sourceId),
-          ),
-        );
+    final res = await showModalBottomSheet<({VideoSource chosen, List<VideoSource> all})>(
+      context: context,
+      backgroundColor: AppColors.surface,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(20))),
+      builder: (_) => _SourcePickerSheet(
+        title: ep.title.trim().isNotEmpty ? ep.title : detail.title,
+        resolve: () => sl<SourceRepository>().sources(ep.url, sourceId: item.sourceId),
+      ),
+    );
     if (res == null || !mounted) return;
     unawaited(
       sl<DownloadManager>().enqueueSource(
@@ -471,12 +396,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     _snack('Added to downloads');
   }
 
-  void _startDownload(
-    MediaDetail detail,
-    String category,
-    String quality,
-    List<Episode> episodes,
-  ) {
+  void _startDownload(MediaDetail detail, String category, String quality, List<Episode> episodes) {
     final item = widget.item;
     unawaited(
       sl<DownloadManager>().enqueueEpisodes(
@@ -493,20 +413,13 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
         malId: detail.malId ?? item.malId,
       ),
     );
-    _snack(
-      episodes.length == 1
-          ? 'Added to downloads'
-          : 'Downloading ${episodes.length} episodes',
-    );
+    _snack(episodes.length == 1 ? 'Added to downloads' : 'Downloading ${episodes.length} episodes');
   }
 
   Future<void> _openRelation(MediaRelation r) async {
     _snack('Finding "${r.title}"…');
     try {
-      final results = await sl<SourceRepository>().search(
-        r.title,
-        sourceId: widget.item.sourceId,
-      );
+      final results = await sl<SourceRepository>().search(r.title, sourceId: widget.item.sourceId);
       if (!mounted) return;
       if (results.isEmpty) {
         _snack('"${r.title}" isn\'t on this source');
@@ -524,10 +437,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
       ..clearSnackBars()
       ..showSnackBar(
         SnackBar(
-          content: Text(
-            msg,
-            style: AppText.caption.copyWith(color: Colors.white),
-          ),
+          content: Text(msg, style: AppText.caption.copyWith(color: Colors.white)),
           backgroundColor: AppColors.surface2,
           behavior: SnackBarBehavior.floating,
           duration: const Duration(seconds: 2),
@@ -542,18 +452,13 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
         if (state.status == DetailStatus.loading) {
           return Scaffold(
             backgroundColor: AppColors.bg,
-            body: Center(
-              child: CircularProgressIndicator(color: AppColors.accent),
-            ),
+            body: Center(child: CircularProgressIndicator(color: AppColors.accent)),
           );
         }
         if (state.status == DetailStatus.error || state.detail == null) {
           return Scaffold(
             backgroundColor: AppColors.bg,
-            body: EmptyState(
-              icon: Icons.error_outline,
-              message: 'Failed to load this title',
-            ),
+            body: EmptyState(icon: Icons.error_outline, message: 'Failed to load this title'),
           );
         }
         return _buildTwoPane(context, state, state.detail!);
@@ -561,11 +466,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     );
   }
 
-  Widget _buildTwoPane(
-    BuildContext context,
-    DetailState state,
-    MediaDetail detail,
-  ) {
+  Widget _buildTwoPane(BuildContext context, DetailState state, MediaDetail detail) {
     final item = widget.item;
     final category = state.category;
     final eps = detail.episodes;
@@ -578,12 +479,8 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     // Resume / play label (mirrors _DetailViewState._buildBody).
     final resume = _resumeTarget(eps);
     final resumeIdx = resume.index;
-    final hasAnyMark = eps.any(
-      (e) => store.get(item.sourceId, item.url, e.id) != null,
-    );
-    final episodeNum = eps.isNotEmpty
-        ? (eps[resumeIdx].number?.toInt() ?? resumeIdx + 1)
-        : 1;
+    final hasAnyMark = eps.any((e) => store.get(item.sourceId, item.url, e.id) != null);
+    final episodeNum = eps.isNotEmpty ? (eps[resumeIdx].number?.toInt() ?? resumeIdx + 1) : 1;
     final buttonLabel = resume.hasResume ? 'Continue E$episodeNum' : 'Play';
 
     // Cover.
@@ -594,13 +491,9 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
     final seasonSet = seasonsOf(eps);
     final hasMultipleSeasons = seasonSet.length > 1;
     final currentSeason = hasMultipleSeasons
-        ? (seasonSet.contains(state.selectedSeason)
-              ? state.selectedSeason
-              : seasonSet.first)
+        ? (seasonSet.contains(state.selectedSeason) ? state.selectedSeason : seasonSet.first)
         : 1;
-    final seasonEps = hasMultipleSeasons
-        ? eps.where((e) => seasonOf(e) == currentSeason).toList()
-        : eps;
+    final seasonEps = hasMultipleSeasons ? eps.where((e) => seasonOf(e) == currentSeason).toList() : eps;
 
     final episodesBySeason = <int, List<Episode>>{};
     if (hasMultipleSeasons) {
@@ -659,10 +552,8 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                       fit: BoxFit.cover,
                                       width: double.infinity,
                                       memCacheWidth: 400,
-                                      placeholder: (_, _) =>
-                                          ColoredBox(color: AppColors.surface2),
-                                      errorWidget: (_, _, _) =>
-                                          ColoredBox(color: AppColors.surface2),
+                                      placeholder: (_, _) => ColoredBox(color: AppColors.surface2),
+                                      errorWidget: (_, _, _) => ColoredBox(color: AppColors.surface2),
                                     )
                                   : ColoredBox(color: AppColors.surface2),
                             ),
@@ -678,9 +569,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                               children: [
                                 Text(
                                   detail.title,
-                                  style: AppText.headline.copyWith(
-                                    fontSize: 18,
-                                  ),
+                                  style: AppText.headline.copyWith(fontSize: 18),
                                   maxLines: 2,
                                   overflow: TextOverflow.ellipsis,
                                 ),
@@ -688,9 +577,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                   const SizedBox(height: 6),
                                   Text(
                                     metaLine,
-                                    style: AppText.caption.copyWith(
-                                      color: AppColors.textSecondary,
-                                    ),
+                                    style: AppText.caption.copyWith(color: AppColors.textSecondary),
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis,
                                   ),
@@ -702,14 +589,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                   key: const ValueKey('tv-detail-play'),
                                   autofocus: true,
                                   variant: TvFocusVariant.pill,
-                                  onTap: eps.isNotEmpty
-                                      ? () => _openPlayer(
-                                          eps,
-                                          resumeIdx,
-                                          detail,
-                                          category,
-                                        )
-                                      : () {},
+                                  onTap: eps.isNotEmpty ? () => _openPlayer(eps, resumeIdx, detail, category) : () {},
                                   semanticLabel: buttonLabel,
                                   // _PlayButton is shared with the phone view —
                                   // exclude its own label Text here instead of
@@ -719,12 +599,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                     child: _PlayButton(
                                       label: buttonLabel,
                                       onPressed: eps.isNotEmpty
-                                          ? () => _openPlayer(
-                                              eps,
-                                              resumeIdx,
-                                              detail,
-                                              category,
-                                            )
+                                          ? () => _openPlayer(eps, resumeIdx, detail, category)
                                           : null,
                                     ),
                                   ),
@@ -764,20 +639,14 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                   key: const ValueKey('tv-detail-ep-search'),
                                   variant: TvFocusVariant.pill,
                                   onTap: _openEpisodeSearch,
-                                  semanticLabel: _epQuery.isEmpty
-                                      ? 'Search episodes'
-                                      : 'Search: $_epQuery',
+                                  semanticLabel: _epQuery.isEmpty ? 'Search episodes' : 'Search: $_epQuery',
                                   // _IconAction is shared with the phone view —
                                   // exclude its own label, same as Play above.
                                   child: ExcludeSemantics(
                                     child: _IconAction(
-                                      icon: _epQuery.isEmpty
-                                          ? Icons.search_rounded
-                                          : Icons.filter_alt_rounded,
+                                      icon: _epQuery.isEmpty ? Icons.search_rounded : Icons.filter_alt_rounded,
                                       active: _epQuery.isNotEmpty,
-                                      label: _epQuery.isEmpty
-                                          ? 'Search episodes'
-                                          : 'Search: $_epQuery',
+                                      label: _epQuery.isEmpty ? 'Search episodes' : 'Search: $_epQuery',
                                       tooltip: 'Search episodes',
                                       onTap: _openEpisodeSearch,
                                     ),
@@ -789,20 +658,15 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                   key: const ValueKey('tv-detail-mylist'),
                                   variant: TvFocusVariant.pill,
                                   onTap: () => _openListSheet(detail),
-                                  semanticLabel:
-                                      _status?.shortLabel ?? 'My List',
+                                  semanticLabel: _status?.shortLabel ?? 'My List',
                                   // _IconAction is shared with the phone view —
                                   // exclude its own label, same as Play above.
                                   child: ExcludeSemantics(
                                     child: _IconAction(
-                                      icon: _inMyList
-                                          ? Icons.check_rounded
-                                          : Icons.add_rounded,
+                                      icon: _inMyList ? Icons.check_rounded : Icons.add_rounded,
                                       active: _inMyList,
                                       label: _status?.shortLabel ?? 'My List',
-                                      tooltip: _inMyList
-                                          ? 'Change status'
-                                          : 'Add to My List',
+                                      tooltip: _inMyList ? 'Change status' : 'Add to My List',
                                       onTap: () => _openListSheet(detail),
                                     ),
                                   ),
@@ -818,15 +682,12 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                     semanticLabel: 'Tracking',
                                     child: ExcludeSemantics(
                                       child: _IconAction(
-                                        icon: _tracked
-                                            ? Icons
-                                                .published_with_changes_rounded
-                                            : Icons.sync_rounded,
+                                        icon: _tracked ? Icons.published_with_changes_rounded : Icons.sync_rounded,
                                         active: _tracked,
                                         label: 'Tracking',
                                         tooltip: _tracked
                                             ? 'Tracked — edit status, score '
-                                                '& progress'
+                                                  '& progress'
                                             : 'Sync status, score & progress',
                                         onTap: () => _openTrackingSheet(detail),
                                       ),
@@ -868,10 +729,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                       onTap: () => setState(() => _tab = i),
                                       semanticLabel: _tabLabels[i],
                                       builder: (focused) => Padding(
-                                        padding: const EdgeInsets.symmetric(
-                                          horizontal: 14,
-                                          vertical: 8,
-                                        ),
+                                        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
                                         // Excluded — semanticLabel above
                                         // already announces the tab name.
                                         child: ExcludeSemantics(
@@ -883,13 +741,8 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                               // white + bold, not a red tint.
                                               color: focused
                                                   ? Colors.black
-                                                  : (_tab == i
-                                                        ? AppColors.textPrimary
-                                                        : AppColors
-                                                              .textSecondary),
-                                              fontWeight: _tab == i
-                                                  ? FontWeight.w700
-                                                  : FontWeight.w500,
+                                                  : (_tab == i ? AppColors.textPrimary : AppColors.textSecondary),
+                                              fontWeight: _tab == i ? FontWeight.w700 : FontWeight.w500,
                                             ),
                                           ),
                                         ),
@@ -916,9 +769,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                 hasMultipleSeasons: hasMultipleSeasons,
                                 seasonSet: seasonSet,
                                 currentSeason: currentSeason,
-                                onSelectSeason: context
-                                    .read<DetailCubit>()
-                                    .selectSeason,
+                                onSelectSeason: context.read<DetailCubit>().selectSeason,
                                 sourceId: item.sourceId,
                                 showId: item.id,
                                 showUrl: item.url,
@@ -927,29 +778,17 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
                                 hasAnyMark: hasAnyMark,
                                 resumeIndex: _resumeIndex,
                                 trackerProgress: _trackerProgress,
-                                onOpen: (i) =>
-                                    _openPlayer(eps, i, detail, category),
-                                onDownload: (ep) => _pickSourceAndDownload(
-                                  ep,
-                                  detail,
-                                  category,
-                                ),
+                                onOpen: (i) => _openPlayer(eps, i, detail, category),
+                                onDownload: (ep) => _pickSourceAndDownload(ep, detail, category),
                               ),
                               // ── Cast ─────────────────────────────────────────
                               _CastTab(
                                 cast: state.cast.isNotEmpty
                                     ? state.cast
-                                    : [
-                                        for (final n in detail.cast)
-                                          CastMember(name: n),
-                                      ],
+                                    : [for (final n in detail.cast) CastMember(name: n)],
                               ),
                               // ── Relations ──────────────────────────────────
-                              _RelationsTab(
-                                relations: state.relations,
-                                onOpen: _openRelation,
-                                tvFocus: true,
-                              ),
+                              _RelationsTab(relations: state.relations, onOpen: _openRelation, tvFocus: true),
                               // ── Details ────────────────────────────────────
                               _DetailsTab(
                                 sourceName: sourceName,
@@ -970,11 +809,7 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
               ],
             ),
           ), // SafeArea
-          const Positioned(
-            top: 8,
-            left: 8,
-            child: SafeArea(child: TvBackButton()),
-          ),
+          const Positioned(top: 8, left: 8, child: SafeArea(child: TvBackButton())),
         ], // Stack children
       ), // Stack (body)
     );
@@ -983,13 +818,12 @@ class _DetailScreenTvState extends State<DetailScreenTv> {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // TV episode list — each row is a [TvFocusable]-wrapped [_EpisodeRow] so
-// D-pad up/down + OK navigates and plays. Simpler than [_EpisodesTab] (no
-// season dropdown, range chips, or grid toggle — touch-only affordances are
-// omitted from the TV path). Uses the SAME [_EpisodeRow] widget the phone
-// Detail uses, so the visual design is byte-for-byte identical.
+// D-pad up/down + OK navigates and plays. Long seasons use the same 50-episode
+// range chips as mobile [_EpisodesTab]. Uses the SAME [_EpisodeRow] widget the
+// phone Detail uses, so the visual design is byte-for-byte identical.
 // ─────────────────────────────────────────────────────────────────────────────
 
-class _TvEpisodeList extends StatelessWidget {
+class _TvEpisodeList extends StatefulWidget {
   const _TvEpisodeList({
     super.key,
     required this.eps,
@@ -1037,67 +871,83 @@ class _TvEpisodeList extends StatelessWidget {
   final String query;
 
   @override
+  State<_TvEpisodeList> createState() => _TvEpisodeListState();
+}
+
+class _TvEpisodeListState extends State<_TvEpisodeList> {
+  int _rangeIndex = 0;
+
+  List<Episode> get _filteredEps => filterEpisodes(widget.seasonEps, widget.query);
+
+  int _initialRange() {
+    if (!widget.hasAnyMark || widget.seasonEps.isEmpty) return 0;
+    final resumeEp = widget.eps[widget.resumeIndex(widget.eps)];
+    final local = _filteredEps.indexOf(resumeEp);
+    return episodeRangeIndex(local);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _rangeIndex = _initialRange();
+  }
+
+  @override
+  void didUpdateWidget(covariant _TvEpisodeList old) {
+    super.didUpdateWidget(old);
+    if (old.currentSeason != widget.currentSeason ||
+        old.query != widget.query ||
+        old.seasonEps.length != widget.seasonEps.length) {
+      _rangeIndex = _initialRange();
+    } else {
+      final maxRange = episodeRangeCount(_filteredEps.length);
+      if (maxRange > 0 && _rangeIndex > maxRange - 1) {
+        _rangeIndex = maxRange - 1;
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final widget = this; // keep the body identical to the stateful version
     final eps = widget.eps;
-    final seasonEps = filterEpisodes(widget.seasonEps, query);
+    final filtered = _filteredEps;
     if (widget.seasonEps.isEmpty) {
-      return const EmptyState(
-        icon: Icons.video_library_outlined,
-        message: 'No episodes available from this source',
-      );
+      return const EmptyState(icon: Icons.video_library_outlined, message: 'No episodes available from this source');
     }
     final store = sl<ResumeStore>();
+    final total = filtered.length;
+    final rangeCount = episodeRangeCount(total);
+    final showRanges = rangeCount > 1;
+    final maxRange = rangeCount == 0 ? 0 : rangeCount - 1;
+    final rangeIndex = _rangeIndex.clamp(0, maxRange);
+    final slice = episodeRangeSlice(rangeIndex, total);
+    final visible = total == 0 ? filtered : filtered.sublist(slice.start, slice.end);
+
     final Widget listView;
-    if (seasonEps.isEmpty) {
-      // Query matched nothing — keep the search field on screen (it's above),
-      // just swap the list for a hint.
-      listView = const EmptyState(
-        icon: Icons.search_off_rounded,
-        message: 'No episodes match your search',
-      );
+    if (filtered.isEmpty) {
+      listView = const EmptyState(icon: Icons.search_off_rounded, message: 'No episodes match your search');
     } else {
       listView = ListView.builder(
         padding: const EdgeInsets.only(bottom: 32),
-        itemCount: seasonEps.length,
+        itemCount: visible.length,
         itemBuilder: (context, i) {
-          final ep = seasonEps[i];
+          final ep = visible[i];
           final fullIndex = eps.indexOf(ep);
           final mark = store.get(widget.sourceId, widget.showUrl, ep.id);
-          final inProgress =
-              mark != null && !mark.finished && mark.duration > Duration.zero;
-          // Watched locally, or at/below the tracker's count (single-season
-          // only — see the phone _stateFor note).
-          final watched = (mark != null && mark.finished) ||
+          final inProgress = mark != null && !mark.finished && mark.duration > Duration.zero;
+          final watched =
+              (mark != null && mark.finished) ||
               (widget.trackerProgress != null &&
                   !widget.hasMultipleSeasons &&
                   ep.number != null &&
                   ep.number!.toInt() <= widget.trackerProgress!);
-          final resume =
-              widget.hasAnyMark && fullIndex == widget.resumeIndex(eps);
+          final resume = widget.hasAnyMark && fullIndex == widget.resumeIndex(eps);
           final fraction = inProgress
-              ? (mark.position.inMilliseconds / mark.duration.inMilliseconds)
-                    .clamp(0.0, 1.0)
+              ? (mark.position.inMilliseconds / mark.duration.inMilliseconds).clamp(0.0, 1.0)
               : 0.0;
-          // Fallback numbers key off the FULL list position, not the filtered
-          // one, so "Episode 7" stays "Episode 7" while a search narrows the list.
           final epNum = ep.number?.toInt() ?? (fullIndex + 1);
-          // Show clean title (strip "S1 E3 -" prefix) for multi-season titles,
-          // matching the phone's _EpisodesTab behaviour.
-          final displayTitle = widget.hasMultipleSeasons
-              ? cleanTitle(ep.title)
-              : ep.title;
-
-          // Wrap the existing _EpisodeRow in TvFocusable so D-pad up/down +
-          // OK-select navigates + triggers playback. The inner InkWell (touch)
-          // still works; both paths fire the same callback.
-          //
-          // Same heading _EpisodeRow builds internally ("N. Title" or
-          // "Episode N") — used as the TalkBack label since _EpisodeRow is
-          // shared with the phone view and isn't touched here.
-          final heading = displayTitle.isNotEmpty
-              ? '$epNum. $displayTitle'
-              : 'Episode $epNum';
+          final displayTitle = widget.hasMultipleSeasons ? cleanTitle(ep.title) : ep.title;
+          final heading = displayTitle.isNotEmpty ? '$epNum. $displayTitle' : 'Episode $epNum';
           return TvListFocusable(
             key: ValueKey('tv-ep-$fullIndex'),
             onTap: () => widget.onOpen(fullIndex),
@@ -1127,16 +977,34 @@ class _TvEpisodeList extends StatelessWidget {
       );
     }
 
-    if (!widget.hasMultipleSeasons) return listView;
-
-    // Multi-season: show a D-pad-navigable season chip row above the list.
-    return Column(
-      children: [
+    final chips = <Widget>[];
+    if (widget.hasMultipleSeasons) {
+      chips.add(
         _TvSeasonChips(
           seasons: widget.seasonSet.toList()..sort(),
           currentSeason: widget.currentSeason,
           onSelect: widget.onSelectSeason,
         ),
+      );
+    }
+    if (showRanges) {
+      chips.add(
+        TvEpisodeRangeChips(
+          count: rangeCount,
+          selected: rangeIndex,
+          labelFor: (i) => episodeRangeLabel(filtered, i),
+          onSelect: (i) => setState(() => _rangeIndex = i),
+        ),
+      );
+    }
+
+    if (chips.isEmpty) return listView;
+
+    return Column(
+      children: [
+        const SizedBox(height: 16),
+        ...chips,
+        const SizedBox(height: 16),
         Expanded(child: listView),
       ],
     );
@@ -1149,11 +1017,7 @@ class _TvEpisodeList extends StatelessWidget {
 // ─────────────────────────────────────────────────────────────────────────────
 
 class _TvSeasonChips extends StatelessWidget {
-  const _TvSeasonChips({
-    required this.seasons,
-    required this.currentSeason,
-    required this.onSelect,
-  });
+  const _TvSeasonChips({required this.seasons, required this.currentSeason, required this.onSelect});
 
   final List<int> seasons;
   final int currentSeason;
@@ -1181,9 +1045,7 @@ class _TvSeasonChips extends StatelessWidget {
               decoration: BoxDecoration(
                 // Current season = solid white chip (black text); focus adds the
                 // pill scale-up on top. No red.
-                color: focused
-                    ? null
-                    : (selected ? Colors.white : AppColors.surface2),
+                color: focused ? null : (selected ? Colors.white : AppColors.surface2),
                 borderRadius: BorderRadius.circular(20),
               ),
               // Excluded — semanticLabel above already announces the season.
@@ -1191,9 +1053,7 @@ class _TvSeasonChips extends StatelessWidget {
                 child: Text(
                   'Season $s',
                   style: AppText.caption.copyWith(
-                    color: focused
-                        ? Colors.black
-                        : (selected ? Colors.black : AppColors.textPrimary),
+                    color: focused ? Colors.black : (selected ? Colors.black : AppColors.textPrimary),
                     fontWeight: FontWeight.w600,
                   ),
                 ),

--- a/lib/features/detail/episode_filter.dart
+++ b/lib/features/detail/episode_filter.dart
@@ -1,5 +1,8 @@
 import '../../core/models/episode.dart';
 
+/// CloudStream-style chunk size for long season navigation (1–50, 51–100, …).
+const kEpisodeRangeChunk = 50;
+
 /// Filters [episodes] by a case-insensitive substring [query] over each
 /// episode's title and number. An empty/whitespace query returns the list
 /// unchanged. A whole-number match ignores the trailing `.0` (so "12" matches
@@ -16,4 +19,31 @@ List<Episode> filterEpisodes(List<Episode> episodes, String query) {
     }
     return false;
   }).toList();
+}
+
+/// How many range chips a list of [total] episodes needs.
+int episodeRangeCount(int total) => (total / kEpisodeRangeChunk).ceil();
+
+/// Which range chip holds [localIndex] in the filtered list (-1 → 0).
+int episodeRangeIndex(int localIndex) =>
+    localIndex < 0 ? 0 : localIndex ~/ kEpisodeRangeChunk;
+
+/// Inclusive [start], exclusive [end] slice bounds for [rangeIndex].
+({int start, int end}) episodeRangeSlice(int rangeIndex, int total) {
+  final start = (rangeIndex * kEpisodeRangeChunk).clamp(0, total);
+  final end = (start + kEpisodeRangeChunk).clamp(0, total);
+  return (start: start, end: end);
+}
+
+/// Display label for a range chip, e.g. `1–50` or `51–60`.
+String episodeNumLabel(Episode e, int fallback) =>
+    (e.number?.toInt() ?? fallback).toString();
+
+String episodeRangeLabel(List<Episode> episodes, int rangeIndex) {
+  final total = episodes.length;
+  if (total == 0) return '';
+  final s = (rangeIndex * kEpisodeRangeChunk).clamp(0, total - 1);
+  final e = ((rangeIndex + 1) * kEpisodeRangeChunk - 1).clamp(0, total - 1);
+  return '${episodeNumLabel(episodes[s], s + 1)}'
+      '–${episodeNumLabel(episodes[e], e + 1)}';
 }

--- a/lib/features/player/tv_exo_player_screen.dart
+++ b/lib/features/player/tv_exo_player_screen.dart
@@ -37,11 +37,13 @@ import '../../core/torrent/torrent_prefs.dart';
 import '../../core/torrent/torrent_service.dart';
 import '../../core/torrent/torrent_util.dart';
 import '../../core/tracker/tracker_hub.dart';
+import '../../core/tv/tv_episode_range_chips.dart';
 import '../../core/tv/tv_focusable.dart';
 import '../../core/tv/tv_keys.dart';
 import '../../core/tv/tv_load_error_dialog.dart';
 import '../../core/ui/badge.dart';
 import '../../core/ui/subtitle_language_picker.dart';
+import '../detail/episode_filter.dart';
 import 'tv_exo_controller.dart';
 import 'tv_track_menu.dart';
 
@@ -138,10 +140,13 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   );
   bool _controlRowFocused = false;
   bool _episodesOpen = false; // the episode-picker overlay
+  int _episodeRangeIndex = 0; // 50-ep chunk in the picker
   // Its own scope so the picker can grab D-pad focus off the root (the root
   // holds focus and a child's autofocus can't steal it — same reason the track
   // menu uses a scope).
   final _episodesScope = FocusScopeNode(debugLabel: 'tvExoEpisodes');
+  final _selectedRangeFocus = FocusNode(debugLabel: 'tvExoSelectedRange');
+  final _currentEpisodeFocus = FocusNode(debugLabel: 'tvExoCurrentEpisode');
 
   bool _subApplied = false; // one-shot preferred-language per (re)load
   bool _subDownloadTried = false; // one auto-download attempt per episode
@@ -1452,7 +1457,10 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
   }
 
   void _openEpisodes() {
-    setState(() => _episodesOpen = true);
+    setState(() {
+      _episodesOpen = true;
+      _episodeRangeIndex = episodeRangeIndex(_index);
+    });
     // Move focus into the picker once it's mounted (autofocus can't steal it
     // from the root); the current episode is the autofocus target in the scope.
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1813,6 +1821,8 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
       n.dispose();
     }
     _episodesScope.dispose();
+    _selectedRangeFocus.dispose();
+    _currentEpisodeFocus.dispose();
     _fillerEps.dispose();
     super.dispose();
   }
@@ -2449,10 +2459,23 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
 
   /// Full-screen episode picker (opened from the control row's Episodes button).
   Widget _episodesOverlay() {
-    return Positioned.fill(
+    final total = _episodes.length;
+    final rangeCount = episodeRangeCount(total);
+    final showRanges = rangeCount > 1;
+    final maxRange = rangeCount == 0 ? 0 : rangeCount - 1;
+    final rangeIndex = _episodeRangeIndex.clamp(0, maxRange);
+    final slice = episodeRangeSlice(rangeIndex, total);
+    final visibleStart = slice.start;
+    final visibleCount = slice.end - slice.start;
+
+    return Positioned(
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 520,
       child: Container(
-        color: Colors.black.withValues(alpha: 0.9),
-        padding: const EdgeInsets.fromLTRB(48, 40, 48, 40),
+        color: Colors.black.withValues(alpha: 0.66),
+        padding: const EdgeInsets.fromLTRB(30, 34, 30, 34),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -2468,71 +2491,117 @@ class _TvExoPlayerScreenState extends State<TvExoPlayerScreen> {
             Expanded(
               child: FocusScope(
                 node: _episodesScope,
-                child: ValueListenableBuilder<Set<int>>(
-                  valueListenable: _fillerEps,
-                  builder: (context, fillers, _) {
-                    return ListView.builder(
-                      // Big cache so D-pad traversal can reach off-screen rows.
-                      cacheExtent: 2000,
-                      itemCount: _episodes.length,
-                      itemBuilder: (context, i) {
-                        final ep = _episodes[i];
-                        final n = ep.number?.toInt() ?? (i + 1);
-                        final title =
-                            episodeDisplayTitle(ep, number: n) ?? 'Episode $n';
-                        final current = i == _index;
-                        final isFiller = fillers.contains(n);
-                        return Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: TvFocusable(
-                            autofocus: current,
-                            scale: 1.0,
-                            onTap: () => _playEpisodeAt(i),
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 20,
-                                vertical: 14,
-                              ),
-                              decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.06),
-                                borderRadius: BorderRadius.circular(10),
-                              ),
-                              child: Row(
-                                children: [
-                                  if (current) ...[
-                                    const Icon(
-                                      Icons.play_arrow_rounded,
-                                      color: Colors.white,
-                                      size: 20,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (showRanges)
+                      TvEpisodeRangeChips(
+                        axis: Axis.vertical,
+                        count: rangeCount,
+                        selected: rangeIndex,
+                        selectedChipFocusNode: _selectedRangeFocus,
+                        episodeReturnFocusNode: _currentEpisodeFocus,
+                        labelFor: (i) => episodeRangeLabel(_episodes, i),
+                        onSelect: (i) =>
+                            setState(() => _episodeRangeIndex = i),
+                      ),
+                    if (showRanges) const SizedBox(width: 16),
+                    Expanded(
+                      child: ValueListenableBuilder<Set<int>>(
+                        valueListenable: _fillerEps,
+                        builder: (context, fillers, _) {
+                          return ListView.builder(
+                            primary: false,
+                            cacheExtent: 2000,
+                            itemCount: visibleCount,
+                            itemBuilder: (context, localI) {
+                              final i = visibleStart + localI;
+                              final ep = _episodes[i];
+                              final n = ep.number?.toInt() ?? (i + 1);
+                              final title = episodeDisplayTitle(ep, number: n) ??
+                                  'Episode $n';
+                              final current = i == _index;
+                              final isFiller = fillers.contains(n);
+                              return Padding(
+                                padding: const EdgeInsets.only(bottom: 8),
+                                child: Focus(
+                                  onKeyEvent: (_, event) {
+                                    if (!showRanges) {
+                                      return KeyEventResult.ignored;
+                                    }
+                                    if (event is KeyDownEvent &&
+                                        event.logicalKey ==
+                                            LogicalKeyboardKey.arrowLeft) {
+                                      _selectedRangeFocus.requestFocus();
+                                      return KeyEventResult.handled;
+                                    }
+                                    return KeyEventResult.ignored;
+                                  },
+                                  child: TvFocusable(
+                                    autofocus: current,
+                                    focusNode:
+                                        current ? _currentEpisodeFocus : null,
+                                    scale: 1.0,
+                                    onTap: () => _playEpisodeAt(i),
+                                    child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 20,
+                                      vertical: 14,
                                     ),
-                                    const SizedBox(width: 8),
-                                  ],
-                                  Expanded(
-                                    child: Text(
-                                      '${i + 1}. $title',
-                                      maxLines: 1,
-                                      overflow: TextOverflow.ellipsis,
-                                      style: TextStyle(
-                                        color: Colors.white,
-                                        fontSize: 16,
-                                        fontWeight: current
-                                            ? FontWeight.w700
-                                            : FontWeight.w500,
-                                      ),
+                                    decoration: BoxDecoration(
+                                      color: current
+                                          ? AppColors.accent.withValues(
+                                              alpha: 0.22,
+                                            )
+                                          : Colors.white.withValues(alpha: 0.06),
+                                      borderRadius: BorderRadius.circular(10),
+                                      border: current
+                                          ? Border.all(
+                                              color: AppColors.accent,
+                                              width: 1.5,
+                                            )
+                                          : null,
+                                    ),
+                                    child: Row(
+                                      children: [
+                                        if (current) ...[
+                                          const Icon(
+                                            Icons.play_arrow_rounded,
+                                            color: Colors.white,
+                                            size: 20,
+                                          ),
+                                          const SizedBox(width: 8),
+                                        ],
+                                        Expanded(
+                                          child: Text(
+                                            'Episode $n · $title',
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: TextStyle(
+                                              color: Colors.white,
+                                              fontSize: 16,
+                                              fontWeight: current
+                                                  ? FontWeight.w700
+                                                  : FontWeight.w500,
+                                            ),
+                                          ),
+                                        ),
+                                        if (isFiller) ...[
+                                          const SizedBox(width: 8),
+                                          const TagBadge(text: 'FILLER'),
+                                        ],
+                                      ],
                                     ),
                                   ),
-                                  if (isFiller) ...[
-                                    const SizedBox(width: 8),
-                                    const TagBadge(text: 'FILLER'),
-                                  ],
-                                ],
+                                ),
                               ),
-                            ),
-                          ),
-                        );
-                      },
-                    );
-                  },
+                            );
+                            },
+                          );
+                        },
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),

--- a/test/core/tv/tv_episode_range_chips_test.dart
+++ b/test/core/tv/tv_episode_range_chips_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:watch_app/core/theme/app_colors.dart';
+import 'package:watch_app/core/tv/tv_episode_range_chips.dart';
+import 'package:watch_app/core/tv/tv_focusable.dart';
+
+void main() {
+  testWidgets('TvEpisodeRangeChips uses accent fill for selected chip', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TvEpisodeRangeChips(
+            count: 2,
+            selected: 0,
+            labelFor: (i) => i == 0 ? '1–50' : '51–60',
+            onSelect: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('1–50'), findsOneWidget);
+    expect(find.text('51–60'), findsOneWidget);
+
+    final selected = tester.widget<Container>(
+      find.descendant(
+        of: find.byKey(const ValueKey('tv-range-0')),
+        matching: find.byType(Container),
+      ).first,
+    );
+    final decoration = selected.decoration! as BoxDecoration;
+    expect(decoration.color, AppColors.accent);
+  });
+
+  testWidgets('TvEpisodeRangeChips wraps chips in TvFocusable box outline', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TvEpisodeRangeChips(
+            count: 2,
+            selected: 1,
+            labelFor: (i) => i == 0 ? '1–50' : '51–60',
+            onSelect: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    final chip = tester.widget<TvFocusable>(
+      find.byKey(const ValueKey('tv-range-1')),
+    );
+    expect(chip.variant, TvFocusVariant.box);
+  });
+
+  testWidgets('TvEpisodeRangeChips hides when count is 1', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TvEpisodeRangeChips(
+            count: 1,
+            selected: 0,
+            labelFor: (_) => '1–50',
+            onSelect: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(TvEpisodeRangeChips), findsOneWidget);
+    expect(find.byKey(const ValueKey('tv-range-0')), findsNothing);
+  });
+}

--- a/test/features/detail/detail_screen_tv_test.dart
+++ b/test/features/detail/detail_screen_tv_test.dart
@@ -110,6 +110,23 @@ class _FakeResumeStore implements ResumeStore {
   ResumeMark? get(String sourceId, String showId, String episodeId) => null;
 }
 
+/// Resume mark on episode 55 only — for range-chip resume tests.
+class _ResumeAtEpisode55Store implements ResumeStore {
+  @override
+  noSuchMethod(Invocation i) => super.noSuchMethod(i);
+
+  @override
+  ResumeMark? get(String sourceId, String showId, String episodeId) {
+    if (episodeId == 'e55') {
+      return ResumeMark(
+        position: const Duration(minutes: 10),
+        duration: const Duration(minutes: 24),
+      );
+    }
+    return null;
+  }
+}
+
 /// Stub [ProviderRegistry] — no registered providers.
 class _FakeProviderRegistry implements ProviderRegistry {
   @override
@@ -206,6 +223,23 @@ const _testDetailWithRelations = MediaDetail(
     MediaRelation(title: 'Prequel Anime', relation: 'Prequel'),
   ],
 );
+
+MediaDetail _longSeasonDetail(int count) => MediaDetail(
+      id: 'long-show',
+      title: 'Long Season Anime',
+      url: 'http://test/long',
+      type: ProviderType.anime,
+      sourceId: 'test',
+      episodes: [
+        for (var i = 1; i <= count; i++)
+          Episode(
+            id: 'e$i',
+            title: 'Episode $i',
+            url: '/e$i',
+            number: i.toDouble(),
+          ),
+      ],
+    );
 
 // ── Test ──────────────────────────────────────────────────────────────────────
 
@@ -764,6 +798,123 @@ void main() {
       await tester.pump(); // let _ensureFiller setState land
 
       expect(find.text('FILLER'), findsOneWidget);
+    },
+  );
+
+  // ── GAP: episode range chips ─────────────────────────────────────────────
+
+  testWidgets(
+    'DetailScreenTv shows range chips and slices episodes for long seasons',
+    (tester) async {
+      final longCubit = DetailCubit(
+        repo: _StubSourceRepository(_longSeasonDetail(60)),
+        url: 'http://test/long',
+        sourceId: 'test',
+        prefs: _FakeTitlePrefs(),
+      );
+      await longCubit.load();
+      addTearDown(longCubit.close);
+
+      const longItem = MediaItem(
+        id: 'long-show',
+        title: 'Long Season Anime',
+        url: 'http://test/long',
+        type: ProviderType.anime,
+        sourceId: 'test',
+      );
+
+      await tester.pumpWidget(
+        BlocProvider<DetailCubit>.value(
+          value: longCubit,
+          child: const MaterialApp(
+            home: DetailScreenTv(item: longItem),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('tv-range-0')), findsOneWidget);
+      expect(find.byKey(const ValueKey('tv-range-1')), findsOneWidget);
+      expect(find.text('1–50'), findsOneWidget);
+      expect(find.text('51–60'), findsOneWidget);
+
+      expect(find.byKey(const ValueKey('tv-ep-0')), findsOneWidget);
+      expect(find.byKey(const ValueKey('tv-ep-50')), findsNothing);
+
+      final range1 = tester.widget<TvFocusable>(
+        find.byKey(const ValueKey('tv-range-1')),
+      );
+      range1.onTap();
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('tv-ep-50')), findsOneWidget);
+      expect(find.byKey(const ValueKey('tv-ep-0')), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'DetailScreenTv hides range chips when a season has 50 or fewer episodes',
+    (tester) async {
+      await tester.pumpWidget(
+        BlocProvider<DetailCubit>.value(
+          value: cubit,
+          child: MaterialApp(
+            home: DetailScreenTv(item: _testItem),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('tv-range-0')), findsNothing);
+      expect(find.byKey(const ValueKey('tv-ep-0')), findsOneWidget);
+      expect(find.byKey(const ValueKey('tv-ep-1')), findsOneWidget);
+      expect(find.byKey(const ValueKey('tv-ep-2')), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'DetailScreenTv opens the resume episode range on first build',
+    (tester) async {
+      await sl.reset();
+      sl.registerSingleton<AppMode>(const AppMode(isTv: true));
+      sl.registerSingleton<MyListStore>(_FakeMyListStore());
+      sl.registerSingleton<ListStatusStore>(_FakeListStatusStore());
+      sl.registerSingleton<ResumeStore>(_ResumeAtEpisode55Store());
+      sl.registerSingleton<ProviderRegistry>(_FakeProviderRegistry());
+      sl.registerSingleton<CloudStreamManager>(_FakeCloudStreamManager());
+      sl.registerSingleton<DownloadManager>(_FakeDownloadManager());
+      sl.registerSingleton<TrackerHub>(TrackerHub(const []));
+
+      final resumeCubit = DetailCubit(
+        repo: _StubSourceRepository(_longSeasonDetail(60)),
+        url: 'http://test/long',
+        sourceId: 'test',
+        prefs: _FakeTitlePrefs(),
+      );
+      await resumeCubit.load();
+      addTearDown(resumeCubit.close);
+      addTearDown(() async => sl.reset());
+
+      const longItem = MediaItem(
+        id: 'long-show',
+        title: 'Long Season Anime',
+        url: 'http://test/long',
+        type: ProviderType.anime,
+        sourceId: 'test',
+      );
+
+      await tester.pumpWidget(
+        BlocProvider<DetailCubit>.value(
+          value: resumeCubit,
+          child: const MaterialApp(
+            home: DetailScreenTv(item: longItem),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('tv-ep-54')), findsOneWidget);
+      expect(find.byKey(const ValueKey('tv-ep-0')), findsNothing);
     },
   );
 }

--- a/test/features/detail/episode_filter_test.dart
+++ b/test/features/detail/episode_filter_test.dart
@@ -50,4 +50,44 @@ void main() {
       expect(r.map((e) => e.id), ['u']);
     });
   });
+
+  group('episode range helpers', () {
+    test('episodeRangeCount splits at 50', () {
+      expect(episodeRangeCount(0), 0);
+      expect(episodeRangeCount(1), 1);
+      expect(episodeRangeCount(50), 1);
+      expect(episodeRangeCount(51), 2);
+      expect(episodeRangeCount(60), 2);
+      expect(episodeRangeCount(100), 2);
+      expect(episodeRangeCount(101), 3);
+    });
+
+    test('episodeRangeIndex maps local index to chunk', () {
+      expect(episodeRangeIndex(-1), 0);
+      expect(episodeRangeIndex(0), 0);
+      expect(episodeRangeIndex(49), 0);
+      expect(episodeRangeIndex(50), 1);
+    });
+
+    test('episodeRangeSlice returns inclusive start, exclusive end', () {
+      expect(episodeRangeSlice(0, 60), (start: 0, end: 50));
+      expect(episodeRangeSlice(1, 60), (start: 50, end: 60));
+      expect(episodeRangeSlice(0, 50), (start: 0, end: 50));
+    });
+
+    test('episodeRangeLabel uses episode numbers with fallbacks', () {
+      final numbered = [
+        for (var i = 1; i <= 60; i++)
+          ep('$i', 'Ep $i', i.toDouble()),
+      ];
+      expect(episodeRangeLabel(numbered, 0), '1–50');
+      expect(episodeRangeLabel(numbered, 1), '51–60');
+
+      final partial = [
+        ep('a', 'First', 51),
+        ep('b', 'Second', null),
+      ];
+      expect(episodeRangeLabel(partial, 0), '51–2');
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Add shared 50-episode range helpers and a reusable `TvEpisodeRangeChips` widget for D-pad focusable `1–50` / `51–100` pills
- Wire range grouping into the TV detail episode list (resume opens the correct chunk; chips hidden for ≤50 episodes)
- Add the same grouping to the native TV player episode pane and the Flutter Exo overlay, with the header and range rail docked on the left while only the episode list scrolls
- Pressing ◀ from an episode focuses the currently selected range chip; ▶ returns to the current episode

## Test plan
- [ ] Open a show with 60+ episodes on TV detail — range chips appear, switching ranges updates the list, resume lands in the right chunk
- [ ] Open episodes in the native TV player (default) — rail stays pinned left while scrolling episodes; ◀/▶ focus moves between selected chip and episode list
- [ ] Repeat with native TV player disabled (Flutter Exo path) — same grouping and focus behavior in the overlay
- [ ] Confirm shows with ≤50 episodes show no range chips on detail or player
- [ ] `fvm flutter test test/features/detail/episode_filter_test.dart test/features/detail/detail_screen_tv_test.dart test/core/tv/tv_episode_range_chips_test.dart`

## Screenshots
<img width="3448" height="1946" alt="CleanShot 2026-08-27 at 15 02 43@2x" src="https://github.com/user-attachments/assets/6eb63b76-ae42-4a29-b38e-81cc6a675f95" />
<img width="3238" height="1810" alt="CleanShot 2026-08-27 at 15 05 39@2x" src="https://github.com/user-attachments/assets/d538178c-e54e-430f-952b-cd1d831b187c" />
