### PR TITLE
feat(tv): Add option to change aspect ratio in TV player

### DIFF
--- a/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
+++ b/android/app/src/main/kotlin/com/spyou/watch_app/TvPlayerActivity.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.view.WindowManager
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
@@ -34,6 +35,7 @@ import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
 import androidx.media3.exoplayer.drm.FrameworkMediaDrm
 import androidx.media3.exoplayer.drm.LocalMediaDrmCallback
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.CaptionStyleCompat
 import androidx.media3.ui.DefaultTimeBar
 import androidx.media3.ui.TimeBar
@@ -129,12 +131,19 @@ class TvPlayerActivity : Activity() {
         var active: TvPlayerActivity? = null
     }
 
+    private val aspectRatios = listOf(
+        Triple("Fit", R.drawable.ic_aspect_ratio_fit, AspectRatioFrameLayout.RESIZE_MODE_FIT),
+        Triple("Fill", R.drawable.ic_aspect_ratio_fill, AspectRatioFrameLayout.RESIZE_MODE_FILL),
+        Triple("Zoom", R.drawable.ic_aspect_ratio_zoom, AspectRatioFrameLayout.RESIZE_MODE_ZOOM),
+    )
+
     private var player: ExoPlayer? = null
     private var reported = false
     private var accent = DEFAULT_ACCENT
 
     private var currentIndex = 0
     private var episodeCount = 1
+    private var currentAspectRatio = 0
     private var episodeLabels: Array<String> = emptyArray()
     private var category = "sub"
     private var availableCategories: List<String> = emptyList()
@@ -175,6 +184,7 @@ class TvPlayerActivity : Activity() {
     private lateinit var btnSources: TextView
     private lateinit var btnAudioSubs: TextView
     private lateinit var btnNext: TextView
+    private lateinit var btnAspectRatio: TextView
     private lateinit var btnMegaskip: TextView
     private lateinit var btnSpeed: TextView
     // MegaSkip jump size in seconds (read from the launch extras).
@@ -499,6 +509,16 @@ class TvPlayerActivity : Activity() {
                 }
             },
         )
+    }
+
+    private fun changeAspectRatio() {
+        currentAspectRatio = (++currentAspectRatio) % aspectRatios.size
+
+        val currentValue = aspectRatios[currentAspectRatio]
+        playerView.resizeMode = currentValue.third
+        btnAspectRatio.text = currentValue.first
+        val drawable = ContextCompat.getDrawable(this, currentValue.second)
+        btnAspectRatio.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
     }
 
     private fun applyResolved(index: Int, m: Map<String, Any?>) {
@@ -1977,6 +1997,7 @@ class TvPlayerActivity : Activity() {
         btnSources = findViewById(R.id.btn_sources)
         btnAudioSubs = findViewById(R.id.btn_audio_subs)
         btnNext = findViewById(R.id.btn_next)
+        btnAspectRatio = findViewById(R.id.btn_ratio)
         btnMegaskip = findViewById(R.id.btn_megaskip)
         btnSpeed = findViewById(R.id.btn_speed)
         fillerBadge = findViewById(R.id.filler_badge)
@@ -2023,7 +2044,7 @@ class TvPlayerActivity : Activity() {
             }
         })
 
-        for (b in listOf(btnEpisodes, btnQuality, btnSources, btnAudioSubs, btnNext, btnMegaskip, btnSpeed)) {
+        for (b in listOf(btnEpisodes, btnQuality, btnSources, btnAudioSubs, btnNext, btnAspectRatio, btnMegaskip, btnSpeed)) {
             // Focusable even in touch mode so requestFocus() works on emulators
             // (real TVs are always in D-pad/non-touch mode anyway).
             applyPillFocus(b, false)
@@ -2047,6 +2068,7 @@ class TvPlayerActivity : Activity() {
         btnSources.bindSingleTapActivate { openSourcesMenu() }
         btnAudioSubs.bindSingleTapActivate { openAvMenu() }
         btnNext.bindSingleTapActivate { loadEpisode(nextAutoplayIndex()) }
+        btnAspectRatio.bindSingleTapActivate { changeAspectRatio() }
         btnMegaskip.bindSingleTapActivate { seekBy(megaSkipSecs * 1000L) }
         btnSpeed.bindSingleTapActivate { openSpeedMenu() }
         updateSpeedPillLabel()

--- a/android/app/src/main/res/drawable/ic_aspect_ratio_fill.xml
+++ b/android/app/src/main/res/drawable/ic_aspect_ratio_fill.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Frame completely filled: content is stretched edge-to-edge -->
+    <path
+        android:pathData="M3,5 H21 V19 H3 Z"
+        android:fillColor="#FFFFFFFF" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_aspect_ratio_fit.xml
+++ b/android/app/src/main/res/drawable/ic_aspect_ratio_fit.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Outer frame: screen bounds -->
+    <path
+        android:pathData="M3,5 H21 V19 H3 Z"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.7"
+        android:strokeLineJoin="round"
+        android:strokeLineCap="round"
+        android:fillColor="@android:color/transparent" />
+    <!-- Inner content, full width, letterboxed top/bottom -->
+    <path
+        android:pathData="M3,8.5 H21 V15.5 H3 Z"
+        android:fillColor="#FFFFFFFF" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_aspect_ratio_zoom.xml
+++ b/android/app/src/main/res/drawable/ic_aspect_ratio_zoom.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Frame: screen bounds (content is cropped to this) -->
+    <path
+        android:pathData="M3,5 H21 V19 H3 Z"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.7"
+        android:strokeLineJoin="round"
+        android:strokeLineCap="round"
+        android:fillColor="@android:color/transparent" />
+    <!-- Corner ticks pushing past the frame: content overflows and gets cropped -->
+    <path
+        android:pathData="M3,5 L1,3 M21,5 L23,3 M3,19 L1,21 M21,19 L23,21"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.7"
+        android:strokeLineCap="round"
+        android:fillColor="@android:color/transparent" />
+</vector>

--- a/android/app/src/main/res/layout/tv_player.xml
+++ b/android/app/src/main/res/layout/tv_player.xml
@@ -79,6 +79,8 @@
 
                 <TextView android:id="@+id/btn_next" style="@style/TvPillButtonSmall" android:layout_marginStart="10dp" android:drawableStart="@drawable/ic_tv_next" android:text="Next Episode" tools:ignore="HardcodedText" />
 
+                <TextView android:id="@+id/btn_ratio" style="@style/TvPillButtonSmall" android:layout_marginStart="10dp" android:drawableStart="@drawable/ic_aspect_ratio_fit" android:text="Fit" tools:ignore="HardcodedText" />
+
                 <!-- MegaSkip: manual jump-forward N seconds (Aniyomi-style).
                      Text + visibility set in code from the megaSkip prefs. -->
                 <!-- Speed pill + MegaSkip sit together on the bottom row. -->


### PR DESCRIPTION
<!--
Target `main`. Keep PRs focused — one fix or feature per PR reviews far faster
than a bundle. See CONTRIBUTING.md if you haven't already.
-->

## What changed

Added the option to change between aspect ratios for TV player

## How you tested it

TV emulator on Android 16. 

Process: Played an episode, changed the aspect ratio from the option beside "Next Episode"

<!-- Device/emulator and Android version, or "iOS simulator". Say what you
actually exercised — "played an episode end to end", "browsed + searched two
sources". "Builds fine" isn't testing. -->

## Checklist

- [x] `flutter analyze` is clean
- [x] `flutter test` passes
- [x] Native build still compiles, if I touched `android/` or `ios/`
- [x] I've read and agree to the [CLA](../CLA.md)
- [ ] New dependency or third-party code? [`NOTICE.md`](../NOTICE.md) updated in this PR
- [ ] Used AI tooling? Disclosed per [`AI_POLICY.md`](../AI_POLICY.md)

## Screenshots

<!-- UI changes: before and after. Drag images in. Delete if not relevant. -->

<img width="1004" height="633" alt="image" src="https://github.com/user-attachments/assets/1f2dd76d-5b67-4aea-af5b-1bd968f5d141" />

# Note

Aspect Ratio change doesn't work for all the video streams. Some streams stay at the same ratio, even when the type is changed from the menu. 