### PR TITLE
fix(tv): Reduce the max width for video title on player screen, which…

### DIFF
--- a/android/app/src/main/res/layout/tv_player.xml
+++ b/android/app/src/main/res/layout/tv_player.xml
@@ -31,7 +31,7 @@
 
         <LinearLayout android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_gravity="top|start" android:layout_marginStart="44dp" android:layout_marginTop="30dp" android:orientation="vertical">
 
-            <TextView android:id="@+id/title" android:layout_width="wrap_content" android:layout_height="wrap_content" android:maxWidth="760dp" android:ellipsize="end" android:maxLines="1" android:textColor="#FFFFFF" android:textSize="24sp" android:textStyle="bold" tools:ignore="HardcodedText" />
+            <TextView android:id="@+id/title" android:layout_width="wrap_content" android:layout_height="wrap_content" android:maxWidth="500dp" android:ellipsize="marquee" android:maxLines="1" android:textColor="#FFFFFF" android:textSize="24sp" android:textStyle="bold" tools:ignore="HardcodedText" />
 
             <TextView android:id="@+id/episode_label" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="2dp" android:textColor="#CCFFFFFF" android:textSize="15sp" />
 


### PR DESCRIPTION


<!--
Target `main`. Keep PRs focused — one fix or feature per PR reviews far faster
than a bundle. See CONTRIBUTING.md if you haven't already.
-->

## What changed

The title on player screen kept overflowing under the quality and source selection menu buttons. this restricts the max width to just before the menu buttons start, so that they don't overlap. 

## Checklist

- [x] `flutter analyze` is clean
- [x] `flutter test` passes
- [x] Native build still compiles, if I touched `android/` or `ios/`
- [x] I've read and agree to the [CLA](../CLA.md)
- [ ] New dependency or third-party code? [`NOTICE.md`](../NOTICE.md) updated in this PR
- [ ] Used AI tooling? Disclosed per [`AI_POLICY.md`](../AI_POLICY.md)

## Screenshots

Before:
<img width="1004" height="633" alt="image" src="https://github.com/user-attachments/assets/1f2dd76d-5b67-4aea-af5b-1bd968f5d141" />

After:
<img width="1009" height="633" alt="image" src="https://github.com/user-attachments/assets/476a0daf-09e2-4a4a-90fe-a9eb56198550" />
